### PR TITLE
Add language toggle and localized copy

### DIFF
--- a/src/lib/components/common/empty-result/empty-result.svelte
+++ b/src/lib/components/common/empty-result/empty-result.svelte
@@ -1,11 +1,12 @@
 <script>
-	import Icon from '$lib/components/ui/icon/icon.svelte';
-	import Large from '$lib/components/ui/typography/large.svelte';
-	import Muted from '$lib/components/ui/typography/muted.svelte';
+        import Icon from '$lib/components/ui/icon/icon.svelte';
+        import Large from '$lib/components/ui/typography/large.svelte';
+        import Muted from '$lib/components/ui/typography/muted.svelte';
+        import UiText from '$lib/data/ui';
 </script>
 
 <div class="flex flex-1 flex-col items-center justify-center gap-2">
-	<Icon className="text-3xl" icon="i-carbon-ai-status-failed" />
-	<Large>Hmmm...</Large>
-	<Muted>The content you are looking for does not exist...</Muted>
+        <Icon className="text-3xl" icon="i-carbon-ai-status-failed" />
+        <Large>{$UiText.emptyTitle}</Large>
+        <Muted>{$UiText.emptyMessage}</Muted>
 </div>

--- a/src/lib/components/common/nav-bar/nav-bar.svelte
+++ b/src/lib/components/common/nav-bar/nav-bar.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-	import { derived } from 'svelte/store';
-	import Button from '$lib/components/ui/button/button.svelte';
-	import {
-		Dialog,
+        import { derived } from 'svelte/store';
+        import Button from '$lib/components/ui/button/button.svelte';
+        import {
+                Dialog,
 		DialogClose,
 		DialogContent,
 		DialogFooter,
@@ -11,15 +11,16 @@
 	import Icon from '$lib/components/ui/icon/icon.svelte';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { Tooltip, TooltipTrigger } from '$lib/components/ui/tooltip';
-	import TooltipContent from '$lib/components/ui/tooltip/tooltip-content.svelte';
-	import H4 from '$lib/components/ui/typography/h4.svelte';
-	import Large from '$lib/components/ui/typography/large.svelte';
-	import BaseData from '$lib/data/base';
-	import NavBarData from '$lib/data/nav-bar';
-	import { href } from '$lib/utils';
-	import { mode, toggleMode } from 'mode-watcher';
+        import TooltipContent from '$lib/components/ui/tooltip/tooltip-content.svelte';
+        import H4 from '$lib/components/ui/typography/h4.svelte';
+        import Large from '$lib/components/ui/typography/large.svelte';
+        import NavBarData from '$lib/data/nav-bar';
+        import UiText from '$lib/data/ui';
+        import { language, setLanguage } from '$lib/stores/language';
+        import { href } from '$lib/utils';
+        import { mode, toggleMode } from 'mode-watcher';
 
-	let isDarkMode = derived(mode, ($mode) => $mode === 'dark');
+        let isDarkMode = derived(mode, ($mode) => $mode === 'dark');
 </script>
 
 <div
@@ -27,25 +28,25 @@
 	style="--bg : hsl(var(--background) / 0.5)"
 >
 	<div class="sm:flex-1">
-		<a href={href('/')} class="flex flex-row items-center justify-start gap-2 text-2xl">
-			<Tooltip>
-				<TooltipTrigger>
-					<Icon icon={NavBarData.left.icon} />
-				</TooltipTrigger>
-				<TooltipContent side="bottom" class="lg:hidden">
-					{NavBarData.left.title}
-				</TooltipContent>
-			</Tooltip>
-			<H4 className="hidden lg:block">{NavBarData.left.title}</H4>
-		</a>
-	</div>
+                <a href={href('/')} class="flex flex-row items-center justify-start gap-2 text-2xl">
+                        <Tooltip>
+                                <TooltipTrigger>
+                                        <Icon icon={$NavBarData.left.icon} />
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom" class="lg:hidden">
+                                        {$NavBarData.left.title}
+                                </TooltipContent>
+                        </Tooltip>
+                        <H4 className="hidden lg:block">{$NavBarData.left.title}</H4>
+                </a>
+        </div>
 
 	<!-- larger than sm -->
 	<div class="hidden flex-[2] flex-row items-center justify-center gap-2 sm:flex">
-		{#each NavBarData.items as item}
-			<a href={href(item.href)}>
-				<Tooltip>
-					<TooltipTrigger>
+                {#each $NavBarData.items as item}
+                        <a href={href(item.href)}>
+                                <Tooltip>
+                                        <TooltipTrigger>
 						<Button class="flex flex-row items-center justify-center gap-2" variant="ghost">
 							<Icon icon={item.icon} className="text-xl" />
 							<div class="hidden lg:block">{item.title}</div>
@@ -57,24 +58,40 @@
 				</Tooltip>
 			</a>
 		{/each}
-	</div>
-	<div class="hidden flex-row items-center justify-end gap-2 sm:flex sm:flex-1">
-		<a href={href('/search')}>
-			<Button variant="ghost" class="text-xl">
-				<Icon icon="i-carbon-search" />
-			</Button>
-		</a>
-		<Button variant="ghost" class="text-xl" on:click={toggleMode}>
-			<Icon icon={$isDarkMode ? 'i-carbon-moon' : 'i-carbon-sun'} />
-		</Button>
+        </div>
+        <div class="hidden flex-row items-center justify-end gap-2 sm:flex sm:flex-1">
+                <a href={href('/search')}>
+                        <Button variant="ghost" class="text-xl">
+                                <Icon icon="i-carbon-search" />
+                        </Button>
+                </a>
+                <div class="flex items-center gap-1">
+                        <Button
+                                variant={$language === 'de' ? 'secondary' : 'ghost'}
+                                size="sm"
+                                on:click={() => setLanguage('de')}
+                        >
+                                DE
+                        </Button>
+                        <Button
+                                variant={$language === 'en' ? 'secondary' : 'ghost'}
+                                size="sm"
+                                on:click={() => setLanguage('en')}
+                        >
+                                EN
+                        </Button>
+                </div>
+                <Button variant="ghost" class="text-xl" on:click={toggleMode}>
+                        <Icon icon={$isDarkMode ? 'i-carbon-moon' : 'i-carbon-sun'} />
+                </Button>
 	</div>
 
 	<!-- sm -->
-	<div class="flex flex-[2] flex-row items-center justify-center sm:hidden">
-		<a href={href('/')}>
-			<Large>{BaseData.fullName}</Large>
-		</a>
-	</div>
+        <div class="flex flex-[2] flex-row items-center justify-center sm:hidden">
+                <a href={href('/')}>
+                        <Large>{$NavBarData.left.title}</Large>
+                </a>
+        </div>
 	<div class="flex flex-row items-center justify-center sm:hidden">
 		<Dialog>
 			<DialogTrigger>
@@ -84,9 +101,9 @@
 			</DialogTrigger>
 			<DialogContent>
 				<div class="flex flex-col gap-2 pt-4">
-					{#each NavBarData.items as item}
-						<DialogClose>
-							<a href={href(item.href)} class="w-full">
+                                        {#each $NavBarData.items as item}
+                                                <DialogClose>
+                                                        <a href={href(item.href)} class="w-full">
 								<Button
 									class="flex w-full flex-row items-center justify-start gap-2"
 									variant="ghost"
@@ -98,30 +115,53 @@
 						</DialogClose>
 					{/each}
 					<Separator />
-					<DialogClose>
-						<a href={href('/search')} class="w-full">
-							<Button class="flex w-full flex-row items-center justify-start gap-2" variant="ghost">
-								<Icon icon={'i-carbon-search'} className="text-xl" />
-								<div>Search</div>
-							</Button>
-						</a>
-					</DialogClose>
-					<Separator />
-					<Button
-						class="flex w-full flex-row items-center justify-start gap-2"
-						variant="ghost"
-						on:click={toggleMode}
-					>
-						<Icon icon={$isDarkMode ? 'i-carbon-moon' : 'i-carbon-sun'} className="text-xl" />
-						<div>{$isDarkMode ? 'Dark' : 'Light'}</div>
-					</Button>
-				</div>
-				<DialogFooter class="items-end">
-					<DialogClose>
-						<Button>Close</Button>
-					</DialogClose>
-				</DialogFooter>
-			</DialogContent>
-		</Dialog>
-	</div>
+                                        <DialogClose>
+                                                <a href={href('/search')} class="w-full">
+                                                        <Button class="flex w-full flex-row items-center justify-start gap-2" variant="ghost">
+                                                                <Icon icon={'i-carbon-search'} className="text-xl" />
+                                                                <div>{$UiText.search}</div>
+                                                        </Button>
+                                                </a>
+                                        </DialogClose>
+                                        <Separator />
+                                        <div class="flex flex-row items-center justify-between gap-2">
+                                                <div class="flex flex-row items-center gap-2">
+                                                        <Icon icon="i-carbon-translate" className="text-xl" />
+                                                        <Large>{$UiText.language}</Large>
+                                                </div>
+                                                <div class="flex flex-row gap-1">
+                                                        <Button
+                                                                variant={$language === 'de' ? 'secondary' : 'ghost'}
+                                                                size="sm"
+                                                                on:click={() => setLanguage('de')}
+                                                        >
+                                                                DE
+                                                        </Button>
+                                                        <Button
+                                                                variant={$language === 'en' ? 'secondary' : 'ghost'}
+                                                                size="sm"
+                                                                on:click={() => setLanguage('en')}
+                                                        >
+                                                                EN
+                                                        </Button>
+                                                </div>
+                                        </div>
+                                        <Separator />
+                                        <Button
+                                                class="flex w-full flex-row items-center justify-start gap-2"
+                                                variant="ghost"
+                                                on:click={toggleMode}
+                                        >
+                                                <Icon icon={$isDarkMode ? 'i-carbon-moon' : 'i-carbon-sun'} className="text-xl" />
+                                                <div>{$isDarkMode ? $UiText.dark : $UiText.light}</div>
+                                        </Button>
+                                </div>
+                                <DialogFooter class="items-end">
+                                        <DialogClose>
+                                                <Button>{$UiText.close}</Button>
+                                        </DialogClose>
+                                </DialogFooter>
+                        </DialogContent>
+                </Dialog>
+        </div>
 </div>

--- a/src/lib/components/common/search-page/search-page.svelte
+++ b/src/lib/components/common/search-page/search-page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Input from '$lib/components/ui/input/input.svelte';
-	import { onMount, type Snippet } from 'svelte';
+        import { onMount, type Snippet } from 'svelte';
+        import UiText from '$lib/data/ui';
 	import TitledPage from '../titled-page/titled-page.svelte';
 
 	let {
@@ -38,6 +39,6 @@
 </script>
 
 <TitledPage {title}>
-	<Input placeholder="Search..." bind:value={query} />
-	{@render children()}
+        <Input placeholder={$UiText.searchPlaceholder} bind:value={query} />
+        {@render children()}
 </TitledPage>

--- a/src/lib/components/education/education-card.svelte
+++ b/src/lib/components/education/education-card.svelte
@@ -10,8 +10,9 @@
 	import { CardContent, CardTitle } from '../ui/card';
 	import FancyCard from '../ui/card/fancy-card.svelte';
 	import Icon from '../ui/icon/icon.svelte';
-	import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-	import Muted from '../ui/typography/muted.svelte';
+        import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+        import Muted from '../ui/typography/muted.svelte';
+        import UiText from '$lib/data/ui';
 
 	const { it }: { it: Education } = $props();
 
@@ -35,33 +36,33 @@
 		</Avatar>
 		<div class="flex flex-col gap-4">
 			<CardTitle>{it.degree}</CardTitle>
-			<Tooltip openDelay={300}>
-				<TooltipTrigger>
-					<Muted className="flex flex-row items-center gap-2">
-						<Icon icon="i-carbon-location" />
-						<div>{location}</div>
-					</Muted>
-				</TooltipTrigger>
-				<TooltipContent>Location</TooltipContent>
-			</Tooltip>
-			<Tooltip openDelay={300}>
-				<TooltipTrigger>
-					<Muted className="flex flex-row items-center gap-2">
-						<Icon icon="i-carbon-calendar" />
-						<div>{period}</div>
-					</Muted>
-				</TooltipTrigger>
-				<TooltipContent>Date range</TooltipContent>
-			</Tooltip>
-			<Tooltip openDelay={300}>
-				<TooltipTrigger>
-					<Muted className="flex flex-row items-center gap-2">
-						<Icon icon="i-carbon-time" />
-						<div>{exactDuration}</div>
-					</Muted>
-					<TooltipContent side="bottom">Exact duration</TooltipContent>
-				</TooltipTrigger>
-			</Tooltip>
+                        <Tooltip openDelay={300}>
+                                <TooltipTrigger>
+                                        <Muted className="flex flex-row items-center gap-2">
+                                                <Icon icon="i-carbon-location" />
+                                                <div>{location}</div>
+                                        </Muted>
+                                </TooltipTrigger>
+                                <TooltipContent>{$UiText.location}</TooltipContent>
+                        </Tooltip>
+                        <Tooltip openDelay={300}>
+                                <TooltipTrigger>
+                                        <Muted className="flex flex-row items-center gap-2">
+                                                <Icon icon="i-carbon-calendar" />
+                                                <div>{period}</div>
+                                        </Muted>
+                                </TooltipTrigger>
+                                <TooltipContent>{$UiText.dateRange}</TooltipContent>
+                        </Tooltip>
+                        <Tooltip openDelay={300}>
+                                <TooltipTrigger>
+                                        <Muted className="flex flex-row items-center gap-2">
+                                                <Icon icon="i-carbon-time" />
+                                                <div>{exactDuration}</div>
+                                        </Muted>
+                                        <TooltipContent side="bottom">{$UiText.exactDuration}</TooltipContent>
+                                </TooltipTrigger>
+                        </Tooltip>
 			<div>
 				{ellipsify(it.shortDescription, 150)}
 			</div>

--- a/src/lib/components/experience/experience-card.svelte
+++ b/src/lib/components/experience/experience-card.svelte
@@ -12,7 +12,8 @@
 	import FancyCard from '../ui/card/fancy-card.svelte';
 	import Icon from '../ui/icon/icon.svelte';
 	import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-	import Muted from '../ui/typography/muted.svelte';
+        import Muted from '../ui/typography/muted.svelte';
+        import UiText from '$lib/data/ui';
 
 	const { it }: { it: Experience } = $props();
 
@@ -23,11 +24,11 @@
 
 	let period = $derived(`${from} - ${to}`);
 
-	let badges = $derived([
-		{ label: it.company, icon: 'i-carbon-building', tooltip: 'Company' },
-		{ label: it.location, icon: 'i-carbon-location', tooltip: 'Location' },
-		{ label: it.contract, icon: 'i-carbon-hourglass', tooltip: 'Contract Type' }
-	] as const);
+        let badges = $derived([
+                { label: it.company, icon: 'i-carbon-building', tooltip: $UiText.company },
+                { label: it.location, icon: 'i-carbon-location', tooltip: $UiText.location },
+                { label: it.contract, icon: 'i-carbon-hourglass', tooltip: $UiText.contractType }
+        ] as const);
 </script>
 
 <FancyCard color={it.color} href={href(`/experience/${it.slug}`)}>
@@ -53,24 +54,24 @@
 					</Tooltip>
 				{/each}
 			</div>
-			<Tooltip openDelay={300}>
-				<TooltipTrigger>
-					<Muted className="flex flex-row items-center gap-2">
-						<Icon icon="i-carbon-calendar" />
-						<div>{period}</div>
-					</Muted>
-				</TooltipTrigger>
-				<TooltipContent>Date range</TooltipContent>
-			</Tooltip>
-			<Tooltip openDelay={300}>
-				<TooltipTrigger>
-					<Muted className="flex flex-row items-center gap-2">
-						<Icon icon="i-carbon-time" />
-						<div>{exactDuration}</div>
-					</Muted>
-					<TooltipContent side="bottom">Exact duration</TooltipContent>
-				</TooltipTrigger>
-			</Tooltip>
+                        <Tooltip openDelay={300}>
+                                <TooltipTrigger>
+                                        <Muted className="flex flex-row items-center gap-2">
+                                                <Icon icon="i-carbon-calendar" />
+                                                <div>{period}</div>
+                                        </Muted>
+                                </TooltipTrigger>
+                                <TooltipContent>{$UiText.dateRange}</TooltipContent>
+                        </Tooltip>
+                        <Tooltip openDelay={300}>
+                                <TooltipTrigger>
+                                        <Muted className="flex flex-row items-center gap-2">
+                                                <Icon icon="i-carbon-time" />
+                                                <div>{exactDuration}</div>
+                                        </Muted>
+                                        <TooltipContent side="bottom">{$UiText.exactDuration}</TooltipContent>
+                                </TooltipTrigger>
+                        </Tooltip>
 			<div>{ellipsify(it.shortDescription, 150)}</div>
 			<div class="flex flex-row flex-wrap gap-2">
 				{#each it.skills as skill (skill.slug)}

--- a/src/lib/data/education.ts
+++ b/src/lib/data/education.ts
@@ -1,36 +1,73 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language, type Language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
 import Assets from './assets';
 import type { Education } from './types';
 
-const title = 'Bildung';
+type LocalizedEducation = Omit<Education, 'degree' | 'description' | 'location' | 'name' | 'organization' | 'shortDescription' | 'subjects'> & {
+        degree: LocalizedString;
+        description: LocalizedString;
+        location: LocalizedString;
+        name: LocalizedString;
+        organization: LocalizedString;
+        shortDescription: LocalizedString;
+        subjects: Array<LocalizedString>;
+};
 
-const items: Array<Education> = [
-	
-	{
-		degree: 'Bachelor of Engineering',
-		description: '',
-		location: 'Kiel, Deutschland',
-		logo: Assets.FH,
-		name: 'Medieningenieur',
-		organization: 'Fachhochschule Kiel',
-		period: { from: new Date(2021, 0, 1), to: new Date(2025, 5, 1) },
-		shortDescription: '',
-		slug: 'dummy-education-item-2',
-		subjects: ['Informatik', 'Softwareentwicklung', 'Java Script', 'Python', 'C#', 'UX/UI Design']
-	},
-	{
-		degree: 'Abitur',
-		description: '',
-		location: 'Altenholz, Deutschland',
-		logo: Assets.GYMAHZ,
-		name: '',
-		organization: 'Gymnasium Altenholz',
-		period: { from: new Date(2012, 0, 1), to: new Date(2020, 5, 1) },
-		shortDescription: '',
-		slug: 'dummy-education-item',
-		subjects: ['Biologie', 'Chemie', 'BYOD']
-	}
+const title: LocalizedString = { de: 'Bildung', en: 'Education' };
+
+const items: Array<LocalizedEducation> = [
+        {
+                degree: { de: 'Bachelor of Engineering', en: 'Bachelor of Engineering' },
+                description: { de: '', en: '' },
+                location: { de: 'Kiel, Deutschland', en: 'Kiel, Germany' },
+                logo: Assets.FH,
+                name: { de: 'Medieningenieur', en: 'Media Engineering' },
+                organization: { de: 'Fachhochschule Kiel', en: 'Kiel University of Applied Sciences' },
+                period: { from: new Date(2021, 0, 1), to: new Date(2025, 5, 1) },
+                shortDescription: { de: '', en: '' },
+                slug: 'dummy-education-item-2',
+                subjects: [
+                        { de: 'Informatik', en: 'Computer Science' },
+                        { de: 'Softwareentwicklung', en: 'Software Development' },
+                        { de: 'Java Script', en: 'JavaScript' },
+                        { de: 'Python', en: 'Python' },
+                        { de: 'C#', en: 'C#' },
+                        { de: 'UX/UI Design', en: 'UX/UI Design' }
+                ]
+        },
+        {
+                degree: { de: 'Abitur', en: 'Abitur (A-level equivalent)' },
+                description: { de: '', en: '' },
+                location: { de: 'Altenholz, Deutschland', en: 'Altenholz, Germany' },
+                logo: Assets.GYMAHZ,
+                name: { de: '', en: '' },
+                organization: { de: 'Gymnasium Altenholz', en: 'Gymnasium Altenholz' },
+                period: { from: new Date(2012, 0, 1), to: new Date(2020, 5, 1) },
+                shortDescription: { de: '', en: '' },
+                slug: 'dummy-education-item',
+                subjects: [
+                        { de: 'Biologie', en: 'Biology' },
+                        { de: 'Chemie', en: 'Chemistry' },
+                        { de: 'BYOD', en: 'BYOD' }
+                ]
+        }
 ];
 
-const EducationData = { title, items };
+const mapEducation = (item: LocalizedEducation, lang: Language): Education => ({
+        ...item,
+        degree: translate(item.degree, lang),
+        description: translate(item.description, lang),
+        location: translate(item.location, lang),
+        name: translate(item.name, lang),
+        organization: translate(item.organization, lang),
+        shortDescription: translate(item.shortDescription, lang),
+        subjects: item.subjects.map((subject) => translate(subject, lang))
+});
+
+const EducationData = derived(language, ($language) => ({
+        title: translate(title, $language),
+        items: items.map((item) => mapEducation(item, $language))
+}));
 
 export default EducationData;

--- a/src/lib/data/experience.ts
+++ b/src/lib/data/experience.ts
@@ -1,102 +1,154 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language, type Language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
 import Assets from './assets';
-import { getSkills } from './skills';
+import { getLocalizedSkills } from './skills';
 import { ContractType, type Experience } from './types';
 
-const title = 'Erfahrung';
+type LocalizedExperience = Omit<Experience, 'name' | 'description' | 'type' | 'location' | 'shortDescription' | 'skills'> & {
+        name: LocalizedString;
+        description: LocalizedString;
+        type: LocalizedString;
+        location: LocalizedString;
+        shortDescription: LocalizedString;
+        skillSlugs: Array<string>;
+};
 
-const items: Array<Experience> = [
-	{
-		slug: 'dataport-bachelor',
-		company: 'Dataport AöR',
-		description: 'Bachelor-Student im Bereich Virtual Reality (VR) und WebGL.',
-		contract: ContractType.Internship,
-		type: 'XR Entwicklung',
-		location: 'Altenholz, Schleswig-Holstein, Deutschland',
-		period: { from: new Date(2024, 11, 1) },
-		skills: getSkills('VR', 'WebGL'),
-		name: 'Bachelor-Student',
-		color: 'red',
-		links: [],
-		logo: Assets.Dataport,
-		shortDescription: 'Bachelor-Student im Bereich VR und WebGL.'
-	},
-	{
-		slug: 'dataport-internship',
-		company: 'Dataport AöR',
-		description: 'Praktikum im Bereich XR Entwicklung mit Fokus auf Virtual Design und Kundenerfahrung.',
-		contract: ContractType.Internship,
-		type: 'XR Entwicklung',
-		location: 'Altenholz, Schleswig-Holstein, Deutschland',
-		period: { from: new Date(2024, 8, 1), to: new Date(2024, 10, 30) },
-		skills: getSkills('Virtual Design', 'Kundenerfahrung'),
-		name: 'Praktikum XR Entwicklung',
-		color: 'blue',
-		links: [],
-		logo: Assets.Dataport,
-		shortDescription: 'Praktikum im Bereich XR Entwicklung.'
-	},
-	{
-		slug: 'social-media-manager',
-		company: 'Dritter Ort',
-		description: 'Verantwortlich für Corporate Social Media und Community Management.',
-		contract: ContractType.PartTime,
-		type: 'Social Media Management',
-		location: 'Kiel, Schleswig-Holstein, Deutschland',
-		period: { from: new Date(2023, 9, 1), to: new Date(2024, 11, 30) },
-		skills: getSkills('Social Media', 'Community Management'),
-		name: 'Social Media-Manager',
-		color: 'green',
-		links: [],
-		logo: Assets.DritterOrt,
-		shortDescription: 'Corporate Social Media Management.'
-	},
-	{
-		slug: 'dominos-koordinator',
-		company: 'Domino\'s Pizza Deutschland',
-		description: 'Koordination und Qualitätssicherung der Lieferanten.',
-		contract: ContractType.WorkingStudent,
-		type: 'Koordination',
-		location: 'Kronshagen, Schleswig-Holstein, Deutschland',
-		period: { from: new Date(2021, 0, 1), to: new Date(2023, 11, 30) },
-		skills: getSkills('Koordination', 'Qualitätskontrolle'),
-		name: 'Koordinator',
-		color: 'purple',
-		links: [],
-		logo: Assets.Dominos,
-		shortDescription: 'Koordination und Lieferantenqualität.'
-	},
-	{
-		slug: 'elanco-produktion',
-		company: 'Elanco',
-		description: 'Mitarbeit in der Produktionstechnik und im Produktionsbetrieb.',
-		contract: ContractType.FullTime,
-		type: 'Produktion',
-		location: 'Kiel, Schleswig-Holstein, Deutschland',
-		period: { from: new Date(2021, 1, 1), to: new Date(2021, 8, 30) },
-		skills: getSkills('Produktionstechnik', 'Produktionsbetrieb'),
-		name: 'Produktionsmitarbeiter',
-		color: 'orange',
-		links: [],
-		logo: Assets.Elanco,
-		shortDescription: 'Produktionstechnik und Produktionsbetrieb.'
-	},
-	{
-		slug: 'bayer-it-intern',
-		company: 'Bayer',
-		description: 'Praktikum im Bereich IT mit Schwerpunkt technischer Support und IT-Infrastruktur.',
-		contract: ContractType.Internship,
-		type: 'IT Support',
-		location: 'Kiel, Schleswig-Holstein, Deutschland',
-		period: { from: new Date(2019, 1, 1), to: new Date(2019, 1, 28) },
-		skills: getSkills('Technischer Support', 'IT-Infrastruktur'),
-		name: 'Praktikant IT',
-		color: 'yellow',
-		links: [],
-		logo: Assets.Bayer,
-		shortDescription: 'Technischer Support und IT-Infrastruktur.'
-	}
+const title: LocalizedString = { de: 'Erfahrung', en: 'Experience' };
+
+const items: Array<LocalizedExperience> = [
+        {
+                slug: 'dataport-bachelor',
+                company: 'Dataport AöR',
+                description: {
+                        de: 'Bachelor-Student im Bereich Virtual Reality (VR) und WebGL.',
+                        en: 'Bachelor student focusing on Virtual Reality (VR) and WebGL.'
+                },
+                contract: ContractType.Internship,
+                type: { de: 'XR Entwicklung', en: 'XR Development' },
+                location: { de: 'Altenholz, Schleswig-Holstein, Deutschland', en: 'Altenholz, Schleswig-Holstein, Germany' },
+                period: { from: new Date(2024, 11, 1) },
+                skillSlugs: ['vr', 'webgl'],
+                name: { de: 'Bachelor-Student', en: 'Bachelor Student' },
+                color: 'red',
+                links: [],
+                logo: Assets.Dataport,
+                shortDescription: {
+                        de: 'Bachelor-Student im Bereich VR und WebGL.',
+                        en: 'Bachelor student working with VR and WebGL.'
+                }
+        },
+        {
+                slug: 'dataport-internship',
+                company: 'Dataport AöR',
+                description: {
+                        de: 'Praktikum im Bereich XR Entwicklung mit Fokus auf Virtual Design und Kundenerfahrung.',
+                        en: 'XR development internship focused on virtual design and customer experience.'
+                },
+                contract: ContractType.Internship,
+                type: { de: 'XR Entwicklung', en: 'XR Development' },
+                location: { de: 'Altenholz, Schleswig-Holstein, Deutschland', en: 'Altenholz, Schleswig-Holstein, Germany' },
+                period: { from: new Date(2024, 8, 1), to: new Date(2024, 10, 30) },
+                skillSlugs: ['virtual-design', 'customer-experience'],
+                name: { de: 'Praktikum XR Entwicklung', en: 'XR Development Internship' },
+                color: 'blue',
+                links: [],
+                logo: Assets.Dataport,
+                shortDescription: { de: 'Praktikum im Bereich XR Entwicklung.', en: 'Internship in XR development.' }
+        },
+        {
+                slug: 'social-media-manager',
+                company: 'Dritter Ort',
+                description: {
+                        de: 'Verantwortlich für Corporate Social Media und Community Management.',
+                        en: 'Responsible for corporate social media and community management.'
+                },
+                contract: ContractType.PartTime,
+                type: { de: 'Social Media Management', en: 'Social Media Management' },
+                location: { de: 'Kiel, Schleswig-Holstein, Deutschland', en: 'Kiel, Schleswig-Holstein, Germany' },
+                period: { from: new Date(2023, 9, 1), to: new Date(2024, 11, 30) },
+                skillSlugs: ['social-media', 'community-management'],
+                name: { de: 'Social Media-Manager', en: 'Social Media Manager' },
+                color: 'green',
+                links: [],
+                logo: Assets.DritterOrt,
+                shortDescription: {
+                        de: 'Corporate Social Media Management.',
+                        en: 'Corporate social media management.'
+                }
+        },
+        {
+                slug: 'dominos-koordinator',
+                company: "Domino's Pizza Deutschland",
+                description: {
+                        de: 'Koordination und Qualitätssicherung der Lieferanten.',
+                        en: 'Coordinated suppliers and ensured delivery quality.'
+                },
+                contract: ContractType.WorkingStudent,
+                type: { de: 'Koordination', en: 'Coordination' },
+                location: { de: 'Kronshagen, Schleswig-Holstein, Deutschland', en: 'Kronshagen, Schleswig-Holstein, Germany' },
+                period: { from: new Date(2021, 0, 1), to: new Date(2023, 11, 30) },
+                skillSlugs: ['coordination', 'quality-control'],
+                name: { de: 'Koordinator', en: 'Coordinator' },
+                color: 'purple',
+                links: [],
+                logo: Assets.Dominos,
+                shortDescription: { de: 'Koordination und Lieferantenqualität.', en: 'Coordination and supplier quality.' }
+        },
+        {
+                slug: 'elanco-produktion',
+                company: 'Elanco',
+                description: {
+                        de: 'Mitarbeit in der Produktionstechnik und im Produktionsbetrieb.',
+                        en: 'Worked in production engineering and day-to-day manufacturing.'
+                },
+                contract: ContractType.FullTime,
+                type: { de: 'Produktion', en: 'Production' },
+                location: { de: 'Kiel, Schleswig-Holstein, Deutschland', en: 'Kiel, Schleswig-Holstein, Germany' },
+                period: { from: new Date(2021, 1, 1), to: new Date(2021, 8, 30) },
+                skillSlugs: ['production-engineering', 'production-operations'],
+                name: { de: 'Produktionsmitarbeiter', en: 'Production Assistant' },
+                color: 'orange',
+                links: [],
+                logo: Assets.Elanco,
+                shortDescription: {
+                        de: 'Produktionstechnik und Produktionsbetrieb.',
+                        en: 'Production engineering and operations.'
+                }
+        },
+        {
+                slug: 'bayer-it-intern',
+                company: 'Bayer',
+                description: {
+                        de: 'Praktikum im Bereich IT mit Schwerpunkt technischer Support und IT-Infrastruktur.',
+                        en: 'IT internship focused on technical support and IT infrastructure.'
+                },
+                contract: ContractType.Internship,
+                type: { de: 'IT Support', en: 'IT Support' },
+                location: { de: 'Kiel, Schleswig-Holstein, Deutschland', en: 'Kiel, Schleswig-Holstein, Germany' },
+                period: { from: new Date(2019, 1, 1), to: new Date(2019, 1, 28) },
+                skillSlugs: ['technical-support', 'it-infrastructure'],
+                name: { de: 'Praktikant IT', en: 'IT Intern' },
+                color: 'yellow',
+                links: [],
+                logo: Assets.Bayer,
+                shortDescription: { de: 'Technischer Support und IT-Infrastruktur.', en: 'Technical support and IT infrastructure.' }
+        }
 ];
 
-const ExperienceData = { title, items };
+const mapExperience = (item: LocalizedExperience, lang: Language): Experience => ({
+        ...item,
+        name: translate(item.name, lang),
+        description: translate(item.description, lang),
+        type: translate(item.type, lang),
+        location: translate(item.location, lang),
+        shortDescription: translate(item.shortDescription, lang),
+        skills: getLocalizedSkills(lang, ...item.skillSlugs)
+});
+
+const ExperienceData = derived(language, ($language) => ({
+        title: translate(title, $language),
+        items: items.map((item) => mapExperience(item, $language))
+}));
 
 export default ExperienceData;

--- a/src/lib/data/home.ts
+++ b/src/lib/data/home.ts
@@ -1,30 +1,33 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language } from '$lib/stores/language';
+import { derived, type Readable } from 'svelte/store';
 import BaseData from './base';
-import { getSkills } from './skills';
+import { getLocalizedSkills } from './skills';
 import type { Skill } from './types';
 
-const title = 'Home';
+const title: LocalizedString = { de: 'Home', en: 'Home' };
 
-const hero: {
-	title: string;
-	description: string;
-	links: Array<{ label: string; href: string; icon: `i-carbon-${string}` }>;
-} = {
-	title: `${BaseData.fullName},`,
-	description:
-		'Ich liebe es, kreative digitale Lösungen zu bauen – ob Web, XR oder einfach coole Projekte. Schau dich gerne um!',
-	links: [
-		{ label: 'GitHub', href: 'https://github.com/L4223', icon: 'i-carbon-logo-github' },
-		{ label: 'LinkedIn', href: 'https://www.linkedin.com/in/lasse-knodt-63a4092ba/', icon: 'i-carbon-logo-linkedin' },
-		{ label: 'Email', href: 'mailto:lasse.knodt@online.de', icon: 'i-carbon-at' }
-	]
+type HeroLink = { label: string; href: string; icon: `i-carbon-${string}` };
+
+const hero = {
+        title: `${BaseData.fullName},`,
+        description: {
+                de: 'Ich liebe es, kreative digitale Lösungen zu bauen – ob Web, XR oder einfach coole Projekte. Schau dich gerne um!',
+                en: 'I love building creative digital solutions—whether that is the web, XR, or just cool side projects. Feel free to take a look around!'
+        } satisfies LocalizedString,
+        links: [
+                { label: 'GitHub', href: 'https://github.com/L4223', icon: 'i-carbon-logo-github' },
+                { label: 'LinkedIn', href: 'https://www.linkedin.com/in/lasse-knodt-63a4092ba/', icon: 'i-carbon-logo-linkedin' },
+                { label: 'Email', href: 'mailto:lasse.knodt@online.de', icon: 'i-carbon-at' }
+        ] satisfies Array<HeroLink>
 };
 
-const carousel: Array<Skill> = getSkills();
+type Hero = { title: string; description: string; links: Array<HeroLink> };
 
-const HomeData = {
-	title,
-	hero,
-	carousel
-};
+const HomeData: Readable<{ title: string; hero: Hero; carousel: Array<Skill> }> = derived(language, ($language) => ({
+        title: translate(title, $language),
+        hero: { ...hero, description: translate(hero.description, $language) },
+        carousel: getLocalizedSkills($language)
+}));
 
 export default HomeData;

--- a/src/lib/data/nav-bar.ts
+++ b/src/lib/data/nav-bar.ts
@@ -1,19 +1,30 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
 import BaseData from './base';
 
-const left = { title: BaseData.fullName, icon: 'i-carbon-code' } as const;
+type NavBarItem = {
+        title: LocalizedString;
+        icon: `i-carbon-${string}`;
+        href: string;
+};
 
-const items: Array<{
-	title: string;
-	icon: `i-carbon-${string}`;
-	href: string;
-}> = [
-	{ title: 'Skills', icon: 'i-carbon-assembly-cluster', href: '/skills' },
-	{ title: 'Projekte', icon: 'i-carbon-cube', href: '/projects' },
-	{ title: 'Erfahrung', icon: 'i-carbon-development', href: '/experience' },
-	{ title: 'Bildung', icon: 'i-carbon-education', href: '/education' },
-	{ title: 'Lebenslauf', icon: 'i-carbon-document', href: '/resume' }
+const left = { title: { de: BaseData.fullName, en: BaseData.fullName } as LocalizedString, icon: 'i-carbon-code' } as const;
+
+const items: Array<NavBarItem> = [
+        { title: { de: 'Skills', en: 'Skills' }, icon: 'i-carbon-assembly-cluster', href: '/skills' },
+        { title: { de: 'Projekte', en: 'Projects' }, icon: 'i-carbon-cube', href: '/projects' },
+        { title: { de: 'Erfahrung', en: 'Experience' }, icon: 'i-carbon-development', href: '/experience' },
+        { title: { de: 'Bildung', en: 'Education' }, icon: 'i-carbon-education', href: '/education' },
+        { title: { de: 'Lebenslauf', en: 'Resume' }, icon: 'i-carbon-document', href: '/resume' }
 ];
 
-const NavBarData = { left, items };
+const NavBarData = derived(language, ($language) => ({
+        left: { title: translate(left.title, $language), icon: left.icon },
+        items: items.map((item) => ({
+                ...item,
+                title: translate(item.title, $language)
+        }))
+}));
 
 export default NavBarData;

--- a/src/lib/data/projects.ts
+++ b/src/lib/data/projects.ts
@@ -1,114 +1,193 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language, type Language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
 import Assets from './assets';
-import { getSkills } from './skills';
+import { getLocalizedSkills } from './skills';
 import type { Project } from './types';
 
-const items: Array<Project> = [
-	{
-		slug: 'big-speech-vr',
-		color: '#4A90E2',
-		description: `
-			<div class="inner">
-				<h1>Big Speech VR</h1>
-	
-				<span class="image right" style="margin-top: 60px"><img src="/screenshots/bigspeechvr1.png" alt=""></span>
-	
-				<h3>Projektbeschreibung</h3>
-				<p>Big Speech VR ist ein innovatives Projekt, das darauf abzielt, die Fähigkeiten von Personen im Bereich der Präsentation durch einen virtuellen Präsentationstrainer namens BigSpeechVR zu verbessern. Das Projekt wurde in Unity entwickelt und bietet eine interaktive Umgebung, in der Nutzer ihre eigenen Präsentationen importieren und vor einem virtuellen Publikum präsentieren können. Durch die Integration verschiedener Funktionen wie interaktives Publikum, Pulstracking und Voicetracking bietet BigSpeechVR ein umfassendes Feedbacksystem, das es den Nutzern ermöglicht, ihre Präsentationsfähigkeiten zu verbessern.</p>
-	
-				<h3>Funktionalitäten</h3>
-				<p>Präsentationsimport: Nutzer können ihre eigenen Präsentationen in das System importieren, einschließlich der Möglichkeit, Stichwörter als Textdatei zu importieren.</p>
-				<p>Auswahl von Features: Vor Beginn der Präsentation können Nutzer verschiedene Features auswählen, darunter ein interaktives Publikum, Pulstracking und Voicetracking.</p>
-				<p>Präsentationsmodus: Nach der Auswahl der gewünschten Features können Nutzer ihre Präsentation starten und vor einem animierten NPC-Publikum präsentieren.</p>
-				<p>Feedbacksystem: Nach Abschluss der Präsentation erhalten die Nutzer eine detaillierte Auswertung, einschließlich Pulswerten, der Anzahl der verwendeten Füllwörter, der Effektivität der Stichpunkte und der Gesamtdauer der Präsentation. Diese Auswertung ermöglicht es den Nutzern, ihren Fortschritt im Laufe der Zeit zu verfolgen und ihre Fähigkeiten zu verbessern.</p>
-				<p>Vergleich mit vorherigen Versuchen: Nutzer haben die Möglichkeit, ihre aktuellen Präsentationen mit ihren vorherigen Versuchen zu vergleichen, um ihren Fortschritt zu überwachen und Verbesserungen zu erkennen.</p>
-	
-				<h3>Technische Details</h3>
-				<p>Das BigSpeechVR-Projekt verwendet verschiedene Technologien und Ressourcen, darunter:</p>
-				<p>3D-Modelle: Alle relevanten 3D-Modelle im Spiel, einschließlich des Studios, des Tutorials und des Handmenüs, wurden von den Entwicklern erstellt.</p>
-				<p>Skripte: Verschiedene benutzerdefinierte Skripte wurden entwickelt, um die Funktionalitäten des Spiels zu steuern, darunter Skripte zur Datenverarbeitung, zur Steuerung von NPC-Reaktionen und zur Handhabung der Präsentationslogik.</p>
-				<p>Integration von Drittanbieter-APIs: BigSpeechVR integriert externe APIs wie Hyperate für das Pulstracking und wit.ai für die Füllwörtererkennung.</p>
-				<p>Verwendung von Paketen und Assets: Das Projekt nutzt verschiedene Unity-Pakete und Assets, darunter OpenXR, XR Core Utilities und TextMeshPro, um eine immersive VR-Erfahrung zu bieten.</p>
-	
-				<div class="row gtr-uniform" style="display: flex; gap: 1rem;">
-					<div class="col-4" style="flex: 1;"><span class="image fit"><img src="/screenshots/bigspeechvr2.png" alt=""></span></div>
-					<div class="col-4" style="flex: 1;"><span class="image fit"><img src="/screenshots/bigspeechvr3.png" alt=""></span></div>
-				</div>
-		
-				<h3>Herausforderungen und Besonderheiten</h3>
-				<p>Das Projekt stellte die Entwickler vor Herausforderungen, insbesondere in Bezug auf die Integration von verschiedenen SDKs und die Gewährleistung einer reibungslosen Interaktion mit VR-Hardware. Trotz einiger technischer Herausforderungen konnten die Entwickler jedoch eine funktionale und ansprechende VR-Präsentationsumgebung schaffen, die es den Nutzern ermöglicht, ihre Fähigkeiten zu verbessern und sich weiterzuentwickeln.</p>
-			</div>
-		`,
-		shortDescription:
-			'VR-gestützter Präsentationstrainer mit interaktivem Feedbacksystem.',
-		links: [
-			{ to: 'https://github.com/L4223/BigSpeechVR', label: 'GitHub Repository' }
-		],
-		logo: Assets.BigSpeechVR,
-		name: 'Big Speech VR',
-		period: {
-			from: new Date(2024, 0, 1),
-			to: new Date(2024, 3, 15)	
-		},
-		skills: getSkills('unity', 'c#', 'vr', 'ai', 'pulstracking', 'voicetracking'),
-		type: 'VR-Anwendung'
-	},
-	{
-		slug: 'bachelor-thesis-webxr',
-		color: '#6A1B9A',
-		description:
-			'Eine interaktive WebXR-Anwendung zur Verbesserung des Lernens im Schulunterricht. Entwicklung einer prototypischen Lösung zur Integration in bestehende LMS.',
-		shortDescription:
-			'Interaktive WebXR-Anwendung für den schulischen Unterricht mit LMS-Integration.',
-		links: [
-			{ to: 'https://github.com/', label: 'GitHub Repository' }
-		],
-		logo: Assets.SchoolXR,
-		name: 'Bachelor Thesis WebXR',
-		period: {
-			from: new Date(2025, 3, 1),
-			to: new Date(2025, 5, 31)
-		},
-		skills: getSkills('webxr', 'js', 'nextjs'),
-		type: 'Forschungsprojekt'
-	},
-									{
-		slug: 'fh-wave-app',
-		color: '#ADD8E6',
-		description: `
-			<p class="mb-3">Unser Projekt, die FH-Wave App, war eine Full-Stack-Anwendung im Rahmen des Moduls "Agile Entwicklungsmethoden". Unser sechsköpfiges Team arbeitete unter der Leitung eines Scrum Masters und eines Product Owners mit der Agilen Softwareentwicklungsmethode Scrum.</p>
+type LocalizedProject = Omit<Project, 'name' | 'description' | 'shortDescription' | 'type' | 'skills'> & {
+        name: LocalizedString;
+        description: LocalizedString;
+        shortDescription: LocalizedString;
+        type: LocalizedString;
+        skillSlugs: Array<string>;
+};
 
-			<h1 class="mt-4 mb-2">Agile Entwicklung mit Scrum</h1>
-			<p class="mb-3">Scrum ermöglichte es uns, flexibel auf Änderungen zu reagieren und die Prioritäten entsprechend anzupassen, was besonders wichtig war, um die Anforderungen und Bedürfnisse der Studierenden der FH Kiel in der FH-Wave App optimal zu erfüllen. Durch regelmäßige Meetings wie Daily Stand-ups, Sprint Reviews und Retrospektiven stellten wir sicher, dass das Team gut informiert und die Arbeit transparent war.</p>
+const title: LocalizedString = { de: 'Projekte', en: 'Projects' };
 
-			<h2 class="mt-4 mb-2">Technologie und Entwicklungsmethoden</h2>
-			<p class="mb-3">Wir konzentrierten uns auf die Programmierung der App mit Flutter, inklusive der Integration von Firebase Auth für eine sichere Anmeldung und einer Datenbank für die Speicherung relevanter Informationen. Dabei nutzten wir Git für eine effiziente Versionskontrolle und Zusammenarbeit im Team. Der Entwicklungsprozess begann mit der Erstellung eines detaillierten Figma-Prototyps, um eine klare Vorstellung von der App zu erhalten, bevor wir mit der eigentlichen App-Entwicklung begannen.</p>
+const items: Array<LocalizedProject> = [
+        {
+                slug: 'big-speech-vr',
+                color: '#4A90E2',
+                description: {
+                        de: `
+                        <div class="inner">
+                                <h1>Big Speech VR</h1>
 
-			<h3 class="mt-4 mb-2">Ziel und Funktionen der FH-Wave App</h3>
-			<p class="mb-3">Die FH-Wave App zielte darauf ab, den Studienalltag der Studierenden an der FH Kiel zu erleichtern. Zu den geplanten Funktionen gehörten unter anderem eine Gruppenfunktion für die Zusammenarbeit in Projekten, ein Kalender mit der Möglichkeit eines Gruppenkalenders, die Auswertung des Stundenplans nach Anfangszeiten für eine bessere Planung, eine Campus-Navigation zur einfachen Routenführung zu bestimmten Gebäuden und ein Darkmode für eine angenehme Benutzererfahrung auch bei wenig Licht.</p>
+                                <span class="image right" style="margin-top: 60px"><img src="/screenshots/bigspeechvr1.png" alt=""></span>
 
-			<p class="mb-3">Mit unserem Projekt FH-Wave App wollten wir einen wirklichen Mehrwert für die Studierenden schaffen und gleichzeitig moderne Technologien und agile Entwicklungsmethoden optimal einsetzen.</p>
+                                <h3>Projektbeschreibung</h3>
+                                <p>Big Speech VR ist ein innovatives Projekt, das darauf abzielt, die Fähigkeiten von Personen im Bereich der Präsentation durch einen virtuellen Präsentationstrainer namens BigSpeechVR zu verbessern. Das Projekt wurde in Unity entwickelt und bietet eine interaktive Umgebung, in der Nutzer ihre eigenen Präsentationen importieren und vor einem virtuellen Publikum präsentieren können. Durch die Integration verschiedener Funktionen wie interaktives Publikum, Pulstracking und Voicetracking bietet BigSpeechVR ein umfassendes Feedbacksystem, das es den Nutzern ermöglicht, ihre Präsentationsfähigkeiten zu verbessern.</p>
 
-			<iframe class="mt-4" style="border: 1px solid rgba(0, 0, 0, 0.1);" width="100%" height="450" src="https://www.figma.com/embed?embed_host=share&amp;url=https%3A%2F%2Fwww.figma.com%2Ffile%2F2BIHFaTz4u4FBwlu6wyJzK%2FAEM%3Ftype%3Ddesign%26node-id%3D0%253A1%26mode%3Ddesign%26t%3DwXGSoGC3UBtcdox7-1" allowfullscreen=""></iframe>
-		`,
-		shortDescription:
-			'Full-Stack-Anwendung zur Unterstützung des Studienalltags an der FH Kiel, entwickelt mit Scrum und modernen Technologien.',
-		links: [
-			{ to: 'https://github.com/L4223/FH-Wave', label: 'GitHub Repository' }
-		],
-		logo: Assets.FHWave,
-		name: 'FH-Wave App',
-		period: {
-			from: new Date(2023, 9, 1),
-			to: new Date(2024, 1, 1)
-		},
-		skills: getSkills('flutter', 'firebase', 'git', 'figma', 'scrum', 'full-stack'),
-		type: 'Full-Stack-Anwendung'
-	}
+                                <h3>Funktionalitäten</h3>
+                                <p>Präsentationsimport: Nutzer können ihre eigenen Präsentationen in das System importieren, einschließlich der Möglichkeit, Stichwörter als Textdatei zu importieren.</p>
+                                <p>Auswahl von Features: Vor Beginn der Präsentation können Nutzer verschiedene Features auswählen, darunter ein interaktives Publikum, Pulstracking und Voicetracking.</p>
+                                <p>Präsentationsmodus: Nach der Auswahl der gewünschten Features können Nutzer ihre Präsentation starten und vor einem animierten NPC-Publikum präsentieren.</p>
+                                <p>Feedbacksystem: Nach Abschluss der Präsentation erhalten die Nutzer eine detaillierte Auswertung, einschließlich Pulswerten, der Anzahl der verwendeten Füllwörter, der Effektivität der Stichpunkte und der Gesamtdauer der Präsentation. Diese Auswertung ermöglicht es den Nutzern, ihren Fortschritt im Laufe der Zeit zu verfolgen und ihre Fähigkeiten zu verbessern.</p>
+                                <p>Vergleich mit vorherigen Versuchen: Nutzer haben die Möglichkeit, ihre aktuellen Präsentationen mit ihren vorherigen Versuchen zu vergleichen, um ihren Fortschritt zu überwachen und Verbesserungen zu erkennen.</p>
+
+                                <h3>Technische Details</h3>
+                                <p>Das BigSpeechVR-Projekt verwendet verschiedene Technologien und Ressourcen, darunter:</p>
+                                <p>3D-Modelle: Alle relevanten 3D-Modelle im Spiel, einschließlich des Studios, des Tutorials und des Handmenüs, wurden von den Entwicklern erstellt.</p>
+                                <p>Skripte: Verschiedene benutzerdefinierte Skripte wurden entwickelt, um die Funktionalitäten des Spiels zu steuern, darunter Skripte zur Datenverarbeitung, zur Steuerung von NPC-Reaktionen und zur Handhabung der Präsentationslogik.</p>
+                                <p>Integration von Drittanbieter-APIs: BigSpeechVR integriert externe APIs wie Hyperate für das Pulstracking und wit.ai für die Füllwörtererkennung.</p>
+                                <p>Verwendung von Paketen und Assets: Das Projekt nutzt verschiedene Unity-Pakete und Assets, darunter OpenXR, XR Core Utilities und TextMeshPro, um eine immersive VR-Erfahrung zu bieten.</p>
+
+                                <div class="row gtr-uniform" style="display: flex; gap: 1rem;">
+                                        <div class="col-4" style="flex: 1;"><span class="image fit"><img src="/screenshots/bigspeechvr2.png" alt=""></span></div>
+                                        <div class="col-4" style="flex: 1;"><span class="image fit"><img src="/screenshots/bigspeechvr3.png" alt=""></span></div>
+                                </div>
+
+                                <h3>Herausforderungen und Besonderheiten</h3>
+                                <p>Das Projekt stellte die Entwickler vor Herausforderungen, insbesondere in Bezug auf die Integration von verschiedenen SDKs und die Gewährleistung einer reibungslosen Interaktion mit VR-Hardware. Trotz einiger technischer Herausforderungen konnten die Entwickler jedoch eine funktionale und ansprechende VR-Präsentationsumgebung schaffen, die es den Nutzern ermöglicht, ihre Fähigkeiten zu verbessern und sich weiterzuentwickeln.</p>
+                        </div>
+                `,
+                        en: `
+                        <div class="inner">
+                                <h1>Big Speech VR</h1>
+
+                                <span class="image right" style="margin-top: 60px"><img src="/screenshots/bigspeechvr1.png" alt=""></span>
+
+                                <h3>Project Overview</h3>
+                                <p>Big Speech VR is a virtual presentation coach built with Unity. Users import their slides and speak in front of an interactive virtual audience while the app tracks their performance.</p>
+
+                                <h3>Key Features</h3>
+                                <p>Presentation import: upload slides and even keyword text files to rehearse with real material.</p>
+                                <p>Feature selection: pick an interactive audience, pulse tracking, or voice tracking before starting.</p>
+                                <p>Presentation mode: present in front of an animated NPC audience in a virtual studio.</p>
+                                <p>Feedback system: after each run the app returns heart rate data, filler word counts, keyword effectiveness, and total duration so progress is measurable over time.</p>
+                                <p>History comparison: compare the current run with previous attempts to see improvement.</p>
+
+                                <h3>Technical Details</h3>
+                                <p>The project uses custom 3D assets for the studio, tutorial, and hand menu, bespoke scripts for data processing and NPC reactions, and integrations like Hyperate for pulse tracking and wit.ai for filler word detection.</p>
+                                <p>Unity packages such as OpenXR, XR Core Utilities, and TextMeshPro provide the VR foundations.</p>
+
+                                <div class="row gtr-uniform" style="display: flex; gap: 1rem;">
+                                        <div class="col-4" style="flex: 1;"><span class="image fit"><img src="/screenshots/bigspeechvr2.png" alt=""></span></div>
+                                        <div class="col-4" style="flex: 1;"><span class="image fit"><img src="/screenshots/bigspeechvr3.png" alt=""></span></div>
+                                </div>
+
+                                <h3>Challenges</h3>
+                                <p>Integrating multiple SDKs and ensuring smooth VR hardware interaction was demanding, but resulted in a responsive training environment that helps users level up their presentation skills.</p>
+                        </div>
+                `
+                },
+                shortDescription: {
+                        de: 'VR-gestützter Präsentationstrainer mit interaktivem Feedbacksystem.',
+                        en: 'VR presentation trainer with interactive feedback.'
+                },
+                links: [
+                        { to: 'https://github.com/L4223/BigSpeechVR', label: 'GitHub Repository' }
+                ],
+                logo: Assets.BigSpeechVR,
+                name: { de: 'Big Speech VR', en: 'Big Speech VR' },
+                period: {
+                        from: new Date(2024, 0, 1),
+                        to: new Date(2024, 3, 15)
+                },
+                skillSlugs: ['unity', 'c#', 'vr', 'ai', 'pulse-tracking', 'voice-tracking'],
+                type: { de: 'VR-Anwendung', en: 'VR Application' }
+        },
+        {
+                slug: 'bachelor-thesis-webxr',
+                color: '#6A1B9A',
+                description: {
+                        de: 'Eine interaktive WebXR-Anwendung zur Verbesserung des Lernens im Schulunterricht. Entwicklung einer prototypischen Lösung zur Integration in bestehende LMS.',
+                        en: 'An interactive WebXR application that enhances classroom learning, delivered as a prototype ready for LMS integration.'
+                },
+                shortDescription: {
+                        de: 'Interaktive WebXR-Anwendung für den schulischen Unterricht mit LMS-Integration.',
+                        en: 'Interactive WebXR classroom experience with LMS integration.'
+                },
+                links: [
+                        { to: 'https://github.com/', label: 'GitHub Repository' }
+                ],
+                logo: Assets.SchoolXR,
+                name: { de: 'Bachelor Thesis WebXR', en: 'Bachelor Thesis WebXR' },
+                period: {
+                        from: new Date(2025, 3, 1),
+                        to: new Date(2025, 5, 31)
+                },
+                skillSlugs: ['webxr', 'js', 'nextjs'],
+                type: { de: 'Forschungsprojekt', en: 'Research Project' }
+        },
+        {
+                slug: 'fh-wave-app',
+                color: '#ADD8E6',
+                description: {
+                        de: `
+                        <p class="mb-3">Unser Projekt, die FH-Wave App, war eine Full-Stack-Anwendung im Rahmen des Moduls "Agile Entwicklungsmethoden". Unser sechsköpfiges Team arbeitete unter der Leitung eines Scrum Masters und eines Product Owners mit der Agilen Softwareentwicklungsmethode Scrum.</p>
+
+                        <h1 class="mt-4 mb-2">Agile Entwicklung mit Scrum</h1>
+                        <p class="mb-3">Scrum ermöglichte es uns, flexibel auf Änderungen zu reagieren und die Prioritäten entsprechend anzupassen, was besonders wichtig war, um die Anforderungen und Bedürfnisse der Studierenden der FH Kiel in der FH-Wave App optimal zu erfüllen. Durch regelmäßige Meetings wie Daily Stand-ups, Sprint Reviews und Retrospektiven stellten wir sicher, dass das Team gut informiert und die Arbeit transparent war.</p>
+
+                        <h2 class="mt-4 mb-2">Technologie und Entwicklungsmethoden</h2>
+                        <p class="mb-3">Wir konzentrierten uns auf die Programmierung der App mit Flutter, inklusive der Integration von Firebase Auth für eine sichere Anmeldung und einer Datenbank für die Speicherung relevanter Informationen. Dabei nutzten wir Git für eine effiziente Versionskontrolle und Zusammenarbeit im Team. Der Entwicklungsprozess begann mit der Erstellung eines detaillierten Figma-Prototyps, um eine klare Vorstellung von der App zu erhalten, bevor wir mit der eigentlichen App-Entwicklung begannen.</p>
+
+                        <h3 class="mt-4 mb-2">Ziel und Funktionen der FH-Wave App</h3>
+                        <p class="mb-3">Die FH-Wave App zielte darauf ab, den Studienalltag der Studierenden an der FH Kiel zu erleichtern. Zu den geplanten Funktionen gehörten unter anderem eine Gruppenfunktion für die Zusammenarbeit in Projekten, ein Kalender mit der Möglichkeit eines Gruppenkalenders, die Auswertung des Stundenplans nach Anfangszeiten für eine bessere Planung, eine Campus-Navigation zur einfachen Routenführung zu bestimmten Gebäuden und ein Darkmode für eine angenehme Benutzererfahrung auch bei wenig Licht.</p>
+
+                        <p class="mb-3">Mit unserem Projekt FH-Wave App wollten wir einen wirklichen Mehrwert für die Studierenden schaffen und gleichzeitig moderne Technologien und agile Entwicklungsmethoden optimal einsetzen.</p>
+
+                        <iframe class="mt-4" style="border: 1px solid rgba(0, 0, 0, 0.1);" width="100%" height="450" src="https://www.figma.com/embed?embed_host=share&amp;url=https%3A%2F%2Fwww.figma.com%2Ffile%2F2BIHFaTz4u4FBwlu6wyJzK%2FAEM%3Ftype%3Ddesign%26node-id%3D0%253A1%26mode%3Ddesign%26t%3DwXGSoGC3UBtcdox7-1" allowfullscreen=""></iframe>
+                `,
+                        en: `
+                        <p class="mb-3">FH-Wave was a full-stack app we built for the “Agile Development Methods” module. Our six-person team worked with a Scrum Master and Product Owner to ship the project using Scrum.</p>
+
+                        <h1 class="mt-4 mb-2">Agile Collaboration</h1>
+                        <p class="mb-3">Scrum let us react to change and reprioritize quickly—essential for meeting student needs at FH Kiel. Daily stand-ups, sprint reviews, and retrospectives kept everyone aligned and transparent.</p>
+
+                        <h2 class="mt-4 mb-2">Technology Choices</h2>
+                        <p class="mb-3">We built the app with Flutter, integrated Firebase Auth for secure sign-in, and used a database to store student data. Git kept collaboration smooth, and a detailed Figma prototype guided development before we wrote code.</p>
+
+                        <h3 class="mt-4 mb-2">Goals & Features</h3>
+                        <p class="mb-3">FH-Wave aimed to simplify student life with project groups, calendars (including group calendars), timetable analytics for better planning, campus navigation, and dark mode for comfortable use at night.</p>
+
+                        <p class="mb-3">The project combined meaningful student value with modern technology and agile practice.</p>
+
+                        <iframe class="mt-4" style="border: 1px solid rgba(0, 0, 0, 0.1);" width="100%" height="450" src="https://www.figma.com/embed?embed_host=share&amp;url=https%3A%2F%2Fwww.figma.com%2Ffile%2F2BIHFaTz4u4FBwlu6wyJzK%2FAEM%3Ftype%3Ddesign%26node-id%3D0%253A1%26mode%3Ddesign%26t%3DwXGSoGC3UBtcdox7-1" allowfullscreen=""></iframe>
+                `
+                },
+                shortDescription: {
+                        de: 'Full-Stack-Anwendung zur Unterstützung des Studienalltags an der FH Kiel, entwickelt mit Scrum und modernen Technologien.',
+                        en: 'Full-stack app to support student life at FH Kiel, built with Scrum and modern tooling.'
+                },
+                links: [
+                        { to: 'https://github.com/L4223/FH-Wave', label: 'GitHub Repository' }
+                ],
+                logo: Assets.FHWave,
+                name: { de: 'FH-Wave App', en: 'FH-Wave App' },
+                period: {
+                        from: new Date(2023, 9, 1),
+                        to: new Date(2024, 1, 1)
+                },
+                skillSlugs: ['flutter', 'firebase', 'git', 'figma', 'scrum', 'full-stack'],
+                type: { de: 'Full-Stack-Anwendung', en: 'Full-stack Application' }
+        }
 ];
 
-const title = 'Projekte';
+const mapProject = (item: LocalizedProject, lang: Language): Project => ({
+        ...item,
+        name: translate(item.name, lang),
+        description: translate(item.description, lang),
+        shortDescription: translate(item.shortDescription, lang),
+        type: translate(item.type, lang),
+        skills: getLocalizedSkills(lang, ...item.skillSlugs)
+});
 
-const ProjectsData = { title, items };
+const ProjectsData = derived(language, ($language) => ({
+        title: translate(title, $language),
+        items: items.map((item) => mapProject(item, $language))
+}));
 
 export default ProjectsData;
-

--- a/src/lib/data/resume.ts
+++ b/src/lib/data/resume.ts
@@ -1,9 +1,12 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
 import { href } from '$lib/utils';
 
-const title = 'Lebenslauf';
+const title: LocalizedString = { de: 'Lebenslauf', en: 'Resume' };
 
 const resume = href('/pdf/resume.pdf');
 
-const ResumeData = { title, resume };
+const ResumeData = derived(language, ($language) => ({ title: translate(title, $language), resume }));
 
 export default ResumeData;

--- a/src/lib/data/skills.ts
+++ b/src/lib/data/skills.ts
@@ -1,272 +1,519 @@
-import type { Skill, SkillCategory } from './types';
 import type { StringWithAutoComplete } from '@riadh-adrani/utils';
 import { omit } from '@riadh-adrani/utils';
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language as languageStore, type Language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
 import Assets from './assets';
 import svelteMd from './md/svelte.md?raw';
+import type { Skill, SkillCategory } from './types';
 
-const defineSkillCategory = <S extends string>(data: SkillCategory<S>): SkillCategory<S> => data;
+type LocalizedCategory<S extends string = string> = Omit<SkillCategory<S>, 'name'> & { name: LocalizedString };
+type LocalizedSkill<S extends string = string> = Omit<Skill<S>, 'name' | 'description' | 'category'> & {
+        name: LocalizedString;
+        description: LocalizedString;
+        category?: LocalizedCategory;
+};
+
+const defineSkillCategory = <S extends string>(data: LocalizedCategory<S>): LocalizedCategory<S> => data;
 
 const categories = [
-	defineSkillCategory({ name: 'Programming', slug: 'programming' }),
-	defineSkillCategory({ name: 'Frontend', slug: 'frontend' }),
-	defineSkillCategory({ name: 'Backend', slug: 'backend' }),
-	defineSkillCategory({ name: 'Game & 3D', slug: 'game-3d' })
+        defineSkillCategory({ name: { de: 'Programmierung', en: 'Programming' }, slug: 'programming' }),
+        defineSkillCategory({ name: { de: 'Frontend', en: 'Frontend' }, slug: 'frontend' }),
+        defineSkillCategory({ name: { de: 'Backend', en: 'Backend' }, slug: 'backend' }),
+        defineSkillCategory({ name: { de: 'Game & 3D', en: 'Game & 3D' }, slug: 'game-3d' })
 ] as const;
 
 const defineSkill = <S extends string>(
-	skill: Omit<Skill<S>, 'category'> & {
-		category?: StringWithAutoComplete<(typeof categories)[number]['slug']>;
-	}
-): Skill<S> => {
-	const out: Skill<S> = omit(skill, 'category');
+        skill: Omit<LocalizedSkill<S>, 'category'> & {
+                category?: StringWithAutoComplete<(typeof categories)[number]['slug']>;
+        }
+): LocalizedSkill<S> => {
+        const out: LocalizedSkill<S> = omit(skill, 'category');
 
-	if (skill.category) {
-		out.category = categories.find((it) => it.slug === skill.category);
-	}
+        if (skill.category) {
+                out.category = categories.find((it) => it.slug === skill.category);
+        }
 
-	return out;
+        return out;
 };
 
-export const getSkills = (
-	...slugs: Array<StringWithAutoComplete<(typeof items)[number]['slug']>>
+const title: LocalizedString = { de: 'Skills', en: 'Skills' };
+
+const items = [
+        defineSkill({
+                slug: 'js',
+                color: 'yellow',
+                description: {
+                        de: 'JavaScript ist eine vielseitige Programmiersprache für Webentwicklung.',
+                        en: 'JavaScript is a versatile programming language for web development.'
+                },
+                logo: Assets.JavaScript,
+                name: { de: 'JavaScript', en: 'JavaScript' },
+                category: 'programming'
+        }),
+        defineSkill({
+                slug: 'ts',
+                color: 'blue',
+                description: {
+                        de: 'TypeScript ist eine typsichere Variante von JavaScript.',
+                        en: 'TypeScript is a typed superset of JavaScript.'
+                },
+                logo: Assets.TypeScript,
+                name: { de: 'TypeScript', en: 'TypeScript' },
+                category: 'programming'
+        }),
+        defineSkill({
+                slug: 'python',
+                color: 'yellow',
+                description: {
+                        de: 'Python ist eine einfach zu erlernende Programmiersprache, die sich in vielen Bereichen verwenden lässt.',
+                        en: 'Python is easy to learn and useful across many domains.'
+                },
+                logo: Assets.Python,
+                name: { de: 'Python', en: 'Python' },
+                category: 'programming'
+        }),
+        defineSkill({
+                slug: 'java',
+                color: 'red',
+                description: {
+                        de: 'Java ist eine weit verbreitete Programmiersprache für Backend-Entwicklung.',
+                        en: 'Java is a widely adopted language for backend development.'
+                },
+                logo: Assets.Java,
+                name: { de: 'Java', en: 'Java' },
+                category: 'programming'
+        }),
+        defineSkill({
+                slug: 'c#',
+                color: 'purple',
+                description: {
+                        de: 'C# ist eine Programmiersprache von Microsoft für die Entwicklung von Windows-Anwendungen aber auch z.B. relevant für Unity.',
+                        en: 'C# is a Microsoft language for Windows applications and popular in Unity projects.'
+                },
+                logo: Assets.CSharp,
+                name: { de: 'C#', en: 'C#' },
+                category: 'programming'
+        }),
+
+        defineSkill({
+                slug: 'html',
+                color: 'orange',
+                description: {
+                        de: 'HTML ist eine Auszeichnungssprache zur Strukturierung von Webinhalten.',
+                        en: 'HTML is a markup language for structuring web content.'
+                },
+                logo: Assets.HTML,
+                name: { de: 'HTML', en: 'HTML' },
+                category: 'frontend'
+        }),
+        defineSkill({
+                slug: 'css',
+                color: 'blue',
+                description: {
+                        de: 'CSS ist eine Stylesheet-Sprache zur Gestaltung von Webinhalten.',
+                        en: 'CSS is a stylesheet language used to style web content.'
+                },
+                logo: Assets.CSS,
+                name: { de: 'CSS', en: 'CSS' },
+                category: 'frontend'
+        }),
+        defineSkill({
+                slug: 'nextjs',
+                color: 'white',
+                description: {
+                        de: 'Next.js ist ein leistungsstarkes, Open-Source React-Framework für die Erstellung von hochperformanten und suchmaschinenoptimierten (SEO-freundlichen) Webanwendungen.',
+                        en: 'Next.js is a powerful open-source React framework for performant, SEO-friendly web apps.'
+                },
+                logo: Assets.NextJS,
+                name: { de: 'Next.js', en: 'Next.js' },
+                category: 'frontend'
+        }),
+        defineSkill({
+                slug: 'reactjs',
+                color: 'cyan',
+                description: {
+                        de: 'React.js ist eine JavaScript-Bibliothek zur Erstellung von Benutzeroberflächen.',
+                        en: 'React.js is a JavaScript library for building user interfaces.'
+                },
+                logo: Assets.ReactJs,
+                name: { de: 'React.js', en: 'React.js' },
+                category: 'frontend'
+        }),
+        defineSkill({
+                slug: 'svelte',
+                color: 'orange',
+                description: { de: svelteMd, en: svelteMd },
+                logo: Assets.Svelte,
+                name: { de: 'Svelte', en: 'Svelte' },
+                category: 'frontend'
+        }),
+        defineSkill({
+                slug: 'flutter',
+                color: 'blue',
+                description: {
+                        de: 'Flutter ist ein Framework zur plattformübergreifenden App-Entwicklung.',
+                        en: 'Flutter is a framework for building cross-platform apps.'
+                },
+                logo: Assets.Flutter,
+                name: { de: 'Flutter', en: 'Flutter' },
+                category: 'frontend'
+        }),
+        defineSkill({
+                slug: 'figma',
+                color: 'purple',
+                description: {
+                        de: 'Figma ist ein webbasiertes Design- und Prototyping-Tool.',
+                        en: 'Figma is a web-based tool for design and prototyping.'
+                },
+                logo: Assets.Figma,
+                name: { de: 'Figma', en: 'Figma' },
+                category: 'frontend'
+        }),
+
+        defineSkill({
+                slug: 'nodejs',
+                color: 'green',
+                description: {
+                        de: 'Node.js ist eine JavaScript-Laufzeitumgebung, die serverseitige Anwendungen ermöglicht.',
+                        en: 'Node.js is a JavaScript runtime for building server-side applications.'
+                },
+                logo: Assets.NodeJs,
+                name: { de: 'Node.js', en: 'Node.js' },
+                category: 'backend'
+        }),
+        defineSkill({
+                slug: 'firebase',
+                color: 'orange',
+                description: {
+                        de: 'Firebase bietet Backend-Dienste wie Authentifizierung und Datenbanken.',
+                        en: 'Firebase provides backend services such as authentication and databases.'
+                },
+                logo: Assets.Firebase,
+                name: { de: 'Firebase', en: 'Firebase' },
+                category: 'backend'
+        }),
+        defineSkill({
+                slug: 'mongo',
+                color: 'green',
+                description: {
+                        de: 'MongoDB ist eine NoSQL-Datenbank, die JSON-ähnliche Dokumente speichert.',
+                        en: 'MongoDB is a NoSQL database storing JSON-like documents.'
+                },
+                logo: Assets.MongoDB,
+                name: { de: 'MongoDB', en: 'MongoDB' },
+                category: 'backend'
+        }),
+        defineSkill({
+                slug: 'docker',
+                color: 'blue',
+                description: {
+                        de: 'Docker ist eine Plattform zur Erstellung und Verwaltung von Containern.',
+                        en: 'Docker is a platform for building and managing containers.'
+                },
+                logo: Assets.Docker,
+                name: { de: 'Docker', en: 'Docker' },
+                category: 'backend'
+        }),
+        defineSkill({
+                slug: 'kubernetes',
+                color: 'lightblue',
+                description: {
+                        de: 'Kubernetes ist eine Open-Source-Plattform zur Verwaltung von Container-Orchestrierungen.',
+                        en: 'Kubernetes is an open-source platform for container orchestration.'
+                },
+                logo: Assets.Kubernetes,
+                name: { de: 'Kubernetes', en: 'Kubernetes' },
+                category: 'backend'
+        }),
+        defineSkill({
+                slug: 'git',
+                color: 'orange',
+                description: {
+                        de: 'Git ist ein Versionskontrollsystem zur Verwaltung von Quellcode.',
+                        en: 'Git is a version control system for managing source code.'
+                },
+                logo: Assets.Git,
+                name: { de: 'Git', en: 'Git' },
+                category: 'backend'
+        }),
+
+        defineSkill({
+                slug: 'unity',
+                color: 'blue',
+                description: {
+                        de: 'Unity ist eine Gameengine zur Entwicklung von 2D- und 3D-Spielen.',
+                        en: 'Unity is a game engine for developing 2D and 3D games.'
+                },
+                logo: Assets.Unity,
+                name: { de: 'Unity', en: 'Unity' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'threejs',
+                color: 'white',
+                description: {
+                        de: 'ThreeJS ist eine JavaScript-Bibliothek zur Erstellung von 3D-Grafiken im Web.',
+                        en: 'ThreeJS is a JavaScript library for building 3D graphics on the web.'
+                },
+                logo: Assets.ThreeJS,
+                name: { de: 'Three JS', en: 'Three JS' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'webxr',
+                color: 'purple',
+                description: {
+                        de: 'WebXR ist eine API zur Erstellung von Virtual- und Augmented-Reality-Erlebnissen im Web.',
+                        en: 'WebXR is an API for creating virtual and augmented reality experiences on the web.'
+                },
+                logo: Assets.WebXR,
+                name: { de: 'WebXR', en: 'WebXR' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'vr',
+                color: 'purple',
+                description: {
+                        de: 'Virtual-Reality-Entwicklung für immersive Anwendungen.',
+                        en: 'Virtual reality development for immersive experiences.'
+                },
+                logo: Assets.WebXR,
+                name: { de: 'VR', en: 'VR' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'webgl',
+                color: 'teal',
+                description: {
+                        de: 'WebGL ermöglicht hardwarebeschleunigte 3D-Grafik direkt im Browser.',
+                        en: 'WebGL enables hardware-accelerated 3D graphics directly in the browser.'
+                },
+                logo: Assets.ThreeJS,
+                name: { de: 'WebGL', en: 'WebGL' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'ai',
+                color: 'blue',
+                description: {
+                        de: 'Künstliche Intelligenz und deren Einsatz in Projekten.',
+                        en: 'Artificial intelligence concepts applied in projects.'
+                },
+                logo: Assets.Python,
+                name: { de: 'AI', en: 'AI' },
+                category: 'programming'
+        }),
+        defineSkill({
+                slug: 'pulse-tracking',
+                color: 'red',
+                description: {
+                        de: 'Pulsmessung und Integration biometrischer Daten.',
+                        en: 'Heart-rate tracking and biometric data integration.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Pulstracking', en: 'Pulse Tracking' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'voice-tracking',
+                color: 'indigo',
+                description: {
+                        de: 'Sprachanalyse zur Erkennung von Füllwörtern und Tonlage.',
+                        en: 'Voice analysis to capture filler words and tone.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Voicetracking', en: 'Voice Tracking' },
+                category: 'game-3d'
+        }),
+        defineSkill({
+                slug: 'virtual-design',
+                color: 'pink',
+                description: {
+                        de: 'Virtuelle Gestaltung von Produkten und Erlebnissen.',
+                        en: 'Virtual design for products and experiences.'
+                },
+                logo: Assets.Figma,
+                name: { de: 'Virtual Design', en: 'Virtual Design' }
+        }),
+        defineSkill({
+                slug: 'customer-experience',
+                color: 'green',
+                description: {
+                        de: 'Gestaltung positiver Kundenerfahrungen in digitalen Produkten.',
+                        en: 'Designing positive customer experiences in digital products.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Kundenerfahrung', en: 'Customer Experience' }
+        }),
+        defineSkill({
+                slug: 'social-media',
+                color: 'blue',
+                description: {
+                        de: 'Strategische Planung und Umsetzung von Social-Media-Inhalten.',
+                        en: 'Strategic planning and execution of social media content.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Social Media', en: 'Social Media' }
+        }),
+        defineSkill({
+                slug: 'community-management',
+                color: 'teal',
+                description: {
+                        de: 'Aufbau und Pflege aktiver Communities.',
+                        en: 'Building and nurturing active communities.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Community Management', en: 'Community Management' }
+        }),
+        defineSkill({
+                slug: 'coordination',
+                color: 'purple',
+                description: {
+                        de: 'Koordination von Teams und Abläufen.',
+                        en: 'Coordinating teams and processes.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Koordination', en: 'Coordination' }
+        }),
+        defineSkill({
+                slug: 'quality-control',
+                color: 'orange',
+                description: {
+                        de: 'Qualitätssicherung und kontinuierliche Verbesserung.',
+                        en: 'Quality assurance and continuous improvement.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Qualitätskontrolle', en: 'Quality Control' }
+        }),
+        defineSkill({
+                slug: 'production-engineering',
+                color: 'yellow',
+                description: {
+                        de: 'Produktionstechnik und Prozessoptimierung.',
+                        en: 'Production engineering and process optimization.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Produktionstechnik', en: 'Production Engineering' }
+        }),
+        defineSkill({
+                slug: 'production-operations',
+                color: 'gray',
+                description: {
+                        de: 'Operativer Produktionsbetrieb und Anlagenbetreuung.',
+                        en: 'Operational production work and plant support.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Produktionsbetrieb', en: 'Production Operations' }
+        }),
+        defineSkill({
+                slug: 'technical-support',
+                color: 'blue',
+                description: {
+                        de: 'Technischer Support für Anwender und Systeme.',
+                        en: 'Technical support for users and systems.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Technischer Support', en: 'Technical Support' }
+        }),
+        defineSkill({
+                slug: 'it-infrastructure',
+                color: 'navy',
+                description: {
+                        de: 'Aufbau und Betreuung von IT-Infrastrukturen.',
+                        en: 'Building and maintaining IT infrastructure.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'IT-Infrastruktur', en: 'IT Infrastructure' }
+        }),
+        defineSkill({
+                slug: 'scrum',
+                color: 'green',
+                description: {
+                        de: 'Agile Projektsteuerung mit Scrum.',
+                        en: 'Agile project management with Scrum.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Scrum', en: 'Scrum' }
+        }),
+        defineSkill({
+                slug: 'full-stack',
+                color: 'cyan',
+                description: {
+                        de: 'Entwicklung über Frontend und Backend hinweg.',
+                        en: 'Development across frontend and backend.'
+                },
+                logo: Assets.Unknown,
+                name: { de: 'Full-Stack', en: 'Full-Stack' }
+        })
+] as const;
+
+const resolveCategory = (slug: string, lang: Language): SkillCategory => {
+        const category = categories.find((it) => it.slug === slug);
+
+        if (!category) {
+                return { name: translate({ de: 'Andere', en: 'Others' }, lang), slug };
+        }
+
+        return { ...category, name: translate(category.name, lang) };
+};
+
+const mapSkill = (skill: LocalizedSkill, lang: Language): Skill => {
+        return {
+                ...skill,
+                name: translate(skill.name, lang),
+                description: translate(skill.description, lang),
+                category: skill.category ? resolveCategory(skill.category.slug, lang) : undefined
+        };
+};
+
+export const getLocalizedSkills = (
+        lang: Language,
+        ...slugs: Array<StringWithAutoComplete<(typeof items)[number]['slug']>>
 ): Array<Skill> => {
-	return items.filter((it) => (slugs.length === 0 ? true : slugs.includes(it.slug)));
+        return items
+                .filter((it) => (slugs.length === 0 ? true : slugs.includes(it.slug)))
+                .map((it) => mapSkill(it, lang));
 };
 
 export const groupByCategory = (
-	query: string
+        lang: Language,
+        list: Array<Skill>,
+        query: string
 ): Array<{ category: SkillCategory; items: Array<Skill> }> => {
-	const out: ReturnType<typeof groupByCategory> = [];
+        const out: ReturnType<typeof groupByCategory> = [];
 
-	const others: Array<Skill> = [];
+        const others: Array<Skill> = [];
 
-	items.forEach((item) => {
-		if (query.trim() && !item.name.toLowerCase().includes(query.trim().toLowerCase())) return;
+        list.forEach((item) => {
+                if (query.trim() && !item.name.toLowerCase().includes(query.trim().toLowerCase())) return;
 
-		// push to others if item does not have a category
-		if (!item.category) {
-			others.push(item);
-			return;
-		}
+                if (!item.category) {
+                        others.push(item);
+                        return;
+                }
 
-		// check if category exists
-		let category = out.find((it) => it.category.slug === item.category?.slug);
+                let category = out.find((it) => it.category.slug === item.category?.slug);
 
-		if (!category) {
-			category = { items: [], category: item.category };
+                if (!category) {
+                        category = { items: [], category: resolveCategory(item.category.slug, lang) };
 
-			out.push(category);
-		}
+                        out.push(category);
+                }
 
-		category.items.push(item);
-	});
+                category.items.push(item);
+        });
 
-	if (others.length !== 0) {
-		out.push({ category: { name: 'Others', slug: 'others' }, items: others });
-	}
+        if (others.length !== 0) {
+                out.push({ category: resolveCategory('others', lang), items: others });
+        }
 
-	return out;
+        return out;
 };
 
-const title = 'Skills';
-
-const items = [
-	defineSkill({
-		slug: 'js',
-		color: 'yellow',
-		description:
-			'JavaScript ist eine vielseitige Programmiersprache für Webentwicklung.',
-		logo: Assets.JavaScript,
-		name: 'JavaScript',
-		category: 'programming'
-	}),
-	defineSkill({
-		slug: 'ts',
-		color: 'blue',
-		description:
-			'TypeScript ist eine typsichere Variante von JavaScript.',
-		logo: Assets.TypeScript,
-		name: 'TypeScript',
-		category: 'programming'
-	}),
-	defineSkill({
-		slug: 'python',
-		color: 'yellow',
-		description:
-			'Python ist eine einfach zu erlernende Programmiersprache, die sich in vielen Bereichen verwenden lässt.',
-		logo: Assets.Python,
-		name: 'Python',
-		category: 'programming'
-	}),
-	defineSkill({
-		slug: 'java',
-		color: 'red',
-		description:
-			'Java ist eine weit verbreitete Programmiersprache für Backend-Entwicklung.',
-		logo: Assets.Java,
-		name: 'Java',
-		category: 'programming'
-	}),
-	defineSkill({
-		slug: 'c#',
-		color: 'purple',
-		description:
-			'C# ist eine Programmiersprache von Microsoft für die Entwicklung von Windows-Anwendungen aber auch z.B. relevant für Unity.',
-		logo: Assets.CSharp,
-		name: 'C#',
-		category: 'programming'
-	}),
-
-	defineSkill({
-		slug: 'html',
-		color: 'orange',
-		description:
-			'HTML ist eine Auszeichnungssprache zur Strukturierung von Webinhalten.',
-		logo: Assets.HTML,
-		name: 'HTML',
-		category: 'frontend'
-	}),
-	defineSkill({
-		slug: 'css',
-		color: 'blue',
-		description:
-			'CSS ist eine Stylesheet-Sprache zur Gestaltung von Webinhalten.',
-		logo: Assets.CSS,
-		name: 'CSS',
-		category: 'frontend'
-	}),
-	defineSkill({
-		slug: 'nextjs',
-		color: 'white',
-		description:
-			'Next.js ist ein leistungsstarkes, Open-Source React-Framework für die Erstellung von hochperformanten und suchmaschinenoptimierten (SEO-freundlichen) Webanwendungen.',
-		logo: Assets.NextJS,
-		name: 'Next.js',
-		category: 'frontend'
-	}),
-	defineSkill({
-		slug: 'reactjs',
-		color: 'cyan',
-		description:
-			'React.js ist eine JavaScript-Bibliothek zur Erstellung von Benutzeroberflächen.',
-		logo: Assets.ReactJs,
-		name: 'React.js',
-		category: 'frontend'
-	}),
-	defineSkill({
-		slug: 'svelte',
-		color: 'orange',
-		description: svelteMd,
-		logo: Assets.Svelte,
-		name: 'Svelte',
-		category: 'frontend'
-	}),
-	defineSkill({
-		slug: 'flutter',
-		color: 'blue',
-		description:
-			'Flutter ist ein Framework zur plattformübergreifenden App-Entwicklung.',
-		logo: Assets.Flutter,
-		name: 'Flutter',
-		category: 'frontend'
-	}),
-	defineSkill({
-		slug: 'figma',
-		color: 'purple',
-		description:
-			'Figma ist ein webbasiertes Design- und Prototyping-Tool.',
-		logo: Assets.Figma,
-		name: 'Figma',
-		category: 'frontend'
-	}),
-
-	defineSkill({
-		slug: 'nodejs',
-		color: 'green',
-		description:
-			'Node.js ist eine JavaScript-Laufzeitumgebung, die serverseitige Anwendungen ermöglicht.',
-		logo: Assets.NodeJs,
-		name: 'Node.js',
-		category: 'backend'
-	}),
-	defineSkill({
-		slug: 'firebase',
-		color: 'orange',
-		description:
-			'Firebase bietet Backend-Dienste wie Authentifizierung und Datenbanken.',
-		logo: Assets.Firebase,
-		name: 'Firebase',
-		category: 'backend'
-	}),
-	defineSkill({
-		slug: 'mongo',
-		color: 'green',
-		description:
-			'MongoDB ist eine NoSQL-Datenbank, die JSON-ähnliche Dokumente speichert.',
-		logo: Assets.MongoDB,
-		name: 'MongoDB',
-		category: 'backend'
-	}),
-	defineSkill({
-		slug: 'docker',
-		color: 'blue',
-		description:
-			'Docker ist eine Plattform zur Erstellung und Verwaltung von Containern.',
-		logo: Assets.Docker,
-		name: 'Docker',
-		category: 'backend'
-	}),
-	defineSkill({
-		slug: 'kubernetes',
-		color: 'lightblue',
-		description:
-			'Kubernetes ist eine Open-Source-Plattform zur Verwaltung von Container-Orchestrierungen.',
-		logo: Assets.Kubernetes,
-		name: 'Kubernetes',
-		category: 'backend'
-	}),
-	defineSkill({
-		slug: 'git',
-		color: 'orange',
-		description:
-			'Git ist ein Versionskontrollsystem zur Verwaltung von Quellcode.',
-		logo: Assets.Git,
-		name: 'Git',
-		category: 'backend'
-	}),
-
-	defineSkill({
-		slug: 'unity',
-		color: 'blue',
-		description:
-			'Unity ist eine Gameengine zur Entwicklung von 2D- und 3D-Spielen.',
-		logo: Assets.Unity,
-		name: 'Unity',
-		category: 'game-3d'
-	}),
-	defineSkill({
-		slug: 'threejs',
-		color: 'white',
-		description:
-			'ThreeJS ist eine JavaScript-Bibliothek zur Erstellung von 3D-Grafiken im Web.',
-		logo: Assets.ThreeJS,
-		name: 'Three JS',
-		category: 'game-3d'
-	}),
-	defineSkill({
-		slug: 'webxr',
-		color: 'purple',
-		description:
-			'WebXR ist eine API zur Erstellung von Virtual- und Augmented-Reality-Erlebnissen im Web.',
-		logo: Assets.WebXR,
-		name: 'WebXR',
-		category: 'game-3d'
-	})
-] as const;
-
-const SkillsData = {
-	title,
-	items
-};
+const SkillsData = derived(languageStore, ($language) => ({
+        title: translate(title, $language),
+        items: getLocalizedSkills($language)
+}));
 
 export default SkillsData;

--- a/src/lib/data/ui.ts
+++ b/src/lib/data/ui.ts
@@ -1,0 +1,33 @@
+import { translate, type LocalizedString } from '$lib/i18n';
+import { language } from '$lib/stores/language';
+import { derived } from 'svelte/store';
+
+const uiCopy: Record<string, LocalizedString> = {
+        search: { de: 'Suche', en: 'Search' },
+        searchPlaceholder: { de: 'Suche...', en: 'Search...' },
+        close: { de: 'Schließen', en: 'Close' },
+        dark: { de: 'Dunkel', en: 'Dark' },
+        light: { de: 'Hell', en: 'Light' },
+        emptyTitle: { de: 'Hmmm...', en: 'Hmm...' },
+        emptyMessage: {
+                de: 'Der gesuchte Inhalt existiert nicht...',
+                en: 'The content you are looking for does not exist...'
+        },
+        company: { de: 'Unternehmen', en: 'Company' },
+        location: { de: 'Standort', en: 'Location' },
+        contractType: { de: 'Vertragsart', en: 'Contract Type' },
+        dateRange: { de: 'Zeitraum', en: 'Date range' },
+        exactDuration: { de: 'Exakte Dauer', en: 'Exact duration' },
+        screenshots: { de: 'Screenshots', en: 'Screenshots' },
+        relatedItems: { de: 'Verwandte Einträge', en: 'Related items' },
+        download: { de: 'Download', en: 'Download' },
+        language: { de: 'Sprache', en: 'Language' }
+};
+
+const UiText = derived(language, ($language) => {
+        const entries = Object.entries(uiCopy).map(([key, value]) => [key, translate(value, $language)]);
+
+        return Object.fromEntries(entries) as Record<keyof typeof uiCopy, string>;
+});
+
+export default UiText;

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,5 @@
+import type { Language } from '$lib/stores/language';
+
+export type LocalizedString = Record<Language, string>;
+
+export const translate = (value: LocalizedString, lang: Language): string => value[lang];

--- a/src/lib/stores/language.ts
+++ b/src/lib/stores/language.ts
@@ -1,0 +1,28 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+export type Language = 'de' | 'en';
+
+const DEFAULT_LANGUAGE: Language = 'de';
+
+const getInitialLanguage = (): Language => {
+        if (!browser) return DEFAULT_LANGUAGE;
+
+        const stored = localStorage.getItem('language') as Language | null;
+
+        return stored === 'en' || stored === 'de' ? stored : DEFAULT_LANGUAGE;
+};
+
+export const language = writable<Language>(getInitialLanguage());
+
+language.subscribe((value) => {
+        if (!browser) return;
+
+        localStorage.setItem('language', value);
+});
+
+export const toggleLanguage = () => {
+        language.update((value) => (value === 'de' ? 'en' : 'de'));
+};
+
+export const setLanguage = (value: Language) => language.set(value);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,50 +1,37 @@
 <script lang="ts">
 	import Title from '$lib/components/common/title/title.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
-	import CarouselContent from '$lib/components/ui/carousel/carousel-content.svelte';
-	import CarouselItem from '$lib/components/ui/carousel/carousel-item.svelte';
-	import CarouselNext from '$lib/components/ui/carousel/carousel-next.svelte';
-	import CarouselPrevious from '$lib/components/ui/carousel/carousel-previous.svelte';
-	import Carousel from '$lib/components/ui/carousel/carousel.svelte';
-	import Icon from '$lib/components/ui/icon/icon.svelte';
-	import ResponsiveContainer from '$lib/components/ui/responsive-container/responsive-container.svelte';
-	import { Tooltip, TooltipContent, TooltipTrigger } from '$lib/components/ui/tooltip';
-	import H1 from '$lib/components/ui/typography/h1.svelte';
-	import Muted from '$lib/components/ui/typography/muted.svelte';
-	import HomeData from '$lib/data/home';
-	import { href } from '$lib/utils';
-	import { mode } from 'mode-watcher';
-	import { type CarouselAPI } from '$lib/components/ui/carousel/context.js';
-	import { onMount } from 'svelte';
-	import RotatingModel from '$lib/components/3d/RotatingModel.svelte';
-	import { Canvas } from '@threlte/core';
+        import Icon from '$lib/components/ui/icon/icon.svelte';
+        import ResponsiveContainer from '$lib/components/ui/responsive-container/responsive-container.svelte';
+        import { Tooltip, TooltipContent, TooltipTrigger } from '$lib/components/ui/tooltip';
+        import H1 from '$lib/components/ui/typography/h1.svelte';
+        import Muted from '$lib/components/ui/typography/muted.svelte';
+        import HomeData from '$lib/data/home';
+        import { translate, type LocalizedString } from '$lib/i18n';
+        import { language } from '$lib/stores/language';
+        import { href } from '$lib/utils';
+        import { mode } from 'mode-watcher';
+        import RotatingModel from '$lib/components/3d/RotatingModel.svelte';
+        import { Canvas } from '@threlte/core';
 
-	let api: CarouselAPI;
-
-	onMount(() => {
-		setInterval(() => {
-			if (!api) return;
-
-			api.scrollNext();
-		}, 2000);
-	});
+        const greeting: LocalizedString = { de: 'Moin!', en: 'Hello!' };
 </script>
 
-<Title title={HomeData.title} />
+<Title title={$HomeData.title} />
 <ResponsiveContainer className="flex flex-col justify-center flex-1">
-	<div
-		class="flex flex-1 flex-col items-center justify-center gap-8 px-14 md:flex-row md:justify-between"
+        <div
+                class="flex flex-1 flex-col items-center justify-center gap-8 px-14 md:flex-row md:justify-between"
 	>
-		<div
-			class="content-container flex flex-col items-center justify-center gap-4 text-center md:items-start md:text-left"
-		>
-			<H1>Moin!</H1>
-			<Muted>{HomeData.hero.description}</Muted>
-			<div class="flex flex-row gap-1">
-				{#each HomeData.hero.links as item}
-					<a href={item.href} target="_blank">
-						<Tooltip>
-							<TooltipTrigger>
+                <div
+                        class="content-container flex flex-col items-center justify-center gap-4 text-center md:items-start md:text-left"
+                >
+                        <H1>{translate(greeting, $language)}</H1>
+                        <Muted>{$HomeData.hero.description}</Muted>
+                        <div class="flex flex-row gap-1">
+                                {#each $HomeData.hero.links as item}
+                                        <a href={item.href} target="_blank">
+                                                <Tooltip>
+                                                        <TooltipTrigger>
 								<Button variant="outline" size="icon">
 									<Icon icon={item.icon} className="text-lg" />
 								</Button>
@@ -76,9 +63,9 @@
 			</Carousel> -->
 
 			<div class="canvas-container">
-				<Canvas>
-					<RotatingModel modelName="me" />
-				</Canvas>
+                                <Canvas>
+                                        <RotatingModel />
+                                </Canvas>
 			</div>
 		</div>
 	</div>

--- a/src/routes/education/+page.svelte
+++ b/src/routes/education/+page.svelte
@@ -7,10 +7,10 @@
 
 	let search = $state('');
 
-	let result = $derived(
-		EducationData.items.filter(
-			(it) =>
-				it.name.toLowerCase().includes(search.toLowerCase()) ||
+        let result = $derived(
+                $EducationData.items.filter(
+                        (it) =>
+                                it.name.toLowerCase().includes(search.toLowerCase()) ||
 				it.description.toLowerCase().includes(search) ||
 				it.location.toLowerCase().includes(search) ||
 				it.degree.toLowerCase().includes(search) ||
@@ -21,7 +21,7 @@
 	const onSearch = (query: string) => (search = query);
 </script>
 
-<SearchPage title={EducationData.title} {onSearch}>
+<SearchPage title={$EducationData.title} {onSearch}>
 	{#if result.length === 0}
 		<EmptyResult />
 	{:else}

--- a/src/routes/education/[slug]/+page.ts
+++ b/src/routes/education/[slug]/+page.ts
@@ -1,10 +1,11 @@
 import EducationData from '$lib/data/education';
+import { get } from 'svelte/store';
 
 export function load({ params }: { params: Record<string, string> }) {
-	if (params.slug) {
-		const item = EducationData.items.find((item) => {
-			return item.slug === params.slug;
-		});
+        if (params.slug) {
+                const item = get(EducationData).items.find((item) => {
+                        return item.slug === params.slug;
+                });
 
 		return { item };
 	}

--- a/src/routes/experience/+page.svelte
+++ b/src/routes/experience/+page.svelte
@@ -7,10 +7,10 @@
 
 	let search = $state('');
 
-	let result = $derived(
-		ExperienceData.items.filter(
-			(it) =>
-				it.name.toLowerCase().includes(search.toLowerCase()) ||
+        let result = $derived(
+                $ExperienceData.items.filter(
+                        (it) =>
+                                it.name.toLowerCase().includes(search.toLowerCase()) ||
 				it.company.toLowerCase().includes(search.toLowerCase()) ||
 				it.description.toLowerCase().includes(search)
 		)
@@ -19,7 +19,7 @@
 	const onSearch = (query: string) => (search = query);
 </script>
 
-<SearchPage title={ExperienceData.title} {onSearch}>
+<SearchPage title={$ExperienceData.title} {onSearch}>
 	{#if result.length === 0}
 		<EmptyResult />
 	{:else}

--- a/src/routes/experience/[slug]/+page.svelte
+++ b/src/routes/experience/[slug]/+page.svelte
@@ -5,18 +5,23 @@
 	import EmptyMarkdown from '$lib/components/common/markdown/empty-markdown.svelte';
 	import Markdown from '$lib/components/common/markdown/markdown.svelte';
 	import ScreenshotCard from '$lib/components/common/screenshot/screenshot-card.svelte';
-	import Badge from '$lib/components/ui/badge/badge.svelte';
-	import Separator from '$lib/components/ui/separator/separator.svelte';
-	import H1 from '$lib/components/ui/typography/h1.svelte';
-	import Muted from '$lib/components/ui/typography/muted.svelte';
-	import Assets from '$lib/data/assets';
-	import type { Experience } from '$lib/data/types';
-	import { computeExactDuration, getMonthAndYear, href } from '$lib/utils';
-	import { mode } from 'mode-watcher';
+        import Badge from '$lib/components/ui/badge/badge.svelte';
+        import Separator from '$lib/components/ui/separator/separator.svelte';
+        import H1 from '$lib/components/ui/typography/h1.svelte';
+        import Muted from '$lib/components/ui/typography/muted.svelte';
+        import Assets from '$lib/data/assets';
+        import ExperienceData from '$lib/data/experience';
+        import UiText from '$lib/data/ui';
+        import { translate, type LocalizedString } from '$lib/i18n';
+        import { language } from '$lib/stores/language';
+        import type { Experience } from '$lib/data/types';
+        import { computeExactDuration, getMonthAndYear, href } from '$lib/utils';
+        import { mode } from 'mode-watcher';
 
-	let { data }: { data: { item?: Experience } } = $props();
+        let { data }: { data: { item?: Experience } } = $props();
 
-	let title = $derived(`${data?.item?.name ?? 'Not Found'} - Skills`);
+        const notFound: LocalizedString = { de: 'Nicht gefunden', en: 'Not found' };
+        let title = $derived(`${data?.item?.name ?? translate(notFound, $language)} - ${$ExperienceData.title}`);
 	let banner = $derived(
 		($mode == 'dark' ? data?.item?.logo.dark : data.item?.logo.light) ?? Assets.Unknown.light
 	);
@@ -69,7 +74,7 @@
 		<Separator />
 		<div class="flex flex-col gap-2 px-4 pt-4">
 			{#if data.item.screenshots && data.item.screenshots.length > 0}
-				<Muted>Screenshots</Muted>
+                                <Muted>{$UiText.screenshots}</Muted>
 				<div class="grid grid-cols-1 gap-2 py-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 					{#each data.item.screenshots as img, index (index)}
 						<ScreenshotCard item={img} />

--- a/src/routes/experience/[slug]/+page.ts
+++ b/src/routes/experience/[slug]/+page.ts
@@ -1,10 +1,11 @@
 import ExperienceData from '$lib/data/experience';
+import { get } from 'svelte/store';
 
 export function load({ params }: { params: Record<string, string> }) {
-	if (params.slug) {
-		const item = ExperienceData.items.find((item) => {
-			return item.slug === params.slug;
-		});
+        if (params.slug) {
+                const item = get(ExperienceData).items.find((item) => {
+                        return item.slug === params.slug;
+                });
 
 		return { item };
 	}

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -4,30 +4,34 @@
 	import ProjectCard from '$lib/components/projects/project-card.svelte';
 	import Icon from '$lib/components/ui/icon/icon.svelte';
 	import Toggle from '$lib/components/ui/toggle/toggle.svelte';
-	import ProjectsData from '$lib/data/projects';
-	import SkillsData from '$lib/data/skills';
-	import type { Skill } from '$lib/data/types';
+        import ProjectsData from '$lib/data/projects';
+        import SkillsData from '$lib/data/skills';
+        import type { Skill } from '$lib/data/types';
 
 	interface SkillFilter extends Skill {
 		isSelected?: boolean;
 	}
 
-	let filters: Array<SkillFilter> = $state(
-		SkillsData.items.filter((it) => {
-			return ProjectsData.items.some((project) =>
-				project.skills.some((skill) => skill.slug === it.slug)
-			);
-		})
-	);
+        let selectedFilters: Record<string, boolean> = $state({});
+
+        let filters: Array<SkillFilter> = $derived(
+                $SkillsData.items
+                        .filter((it) =>
+                                $ProjectsData.items.some((project) =>
+                                        project.skills.some((skill) => skill.slug === it.slug)
+                                )
+                        )
+                        .map((it) => ({ ...it, isSelected: selectedFilters[it.slug] ?? false }))
+        );
 
 	let search = $state('');
-	let result = $derived(
-		ProjectsData.items.filter((project) => {
-			const isFiltered =
-				filters.every((item) => !item.isSelected) ||
-				project.skills.some((tech) =>
-					filters.some((filter) => filter.isSelected && filter.slug === tech.slug)
-				);
+        let result = $derived(
+                $ProjectsData.items.filter((project) => {
+                        const isFiltered =
+                                filters.every((item) => !item.isSelected) ||
+                                project.skills.some((tech) =>
+                                        filters.some((filter) => filter.isSelected && filter.slug === tech.slug)
+                                );
 
 			const isSearched =
 				search.trim().length === 0 ||
@@ -37,14 +41,14 @@
 		})
 	);
 
-	const toggleSelected = (slug: string) => {
-		filters = filters.map((it) => (it.slug === slug ? { ...it, isSelected: !it.isSelected } : it));
-	};
+        const toggleSelected = (slug: string) => {
+                selectedFilters = { ...selectedFilters, [slug]: !selectedFilters[slug] };
+        };
 
 	const onSearch = (query: string) => (search = query);
 </script>
 
-<SearchPage title={ProjectsData.title} {onSearch}>
+<SearchPage title={$ProjectsData.title} {onSearch}>
 	<div class="flex flex-1 flex-col gap-8">
 		<div class="flex flex-row flex-wrap gap-2">
 			{#each filters as it (it.slug)}

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -4,18 +4,23 @@
 	import FancyBanner from '$lib/components/common/fancy-banner/fancy-banner.svelte';
 	import EmptyMarkdown from '$lib/components/common/markdown/empty-markdown.svelte';
 	import ScreenshotCard from '$lib/components/common/screenshot/screenshot-card.svelte';
-	import Badge from '$lib/components/ui/badge/badge.svelte';
-	import Separator from '$lib/components/ui/separator/separator.svelte';
-	import H1 from '$lib/components/ui/typography/h1.svelte';
-	import Muted from '$lib/components/ui/typography/muted.svelte';
-	import Assets from '$lib/data/assets';
-	import type { Project } from '$lib/data/types';
-	import { computeExactDuration, getMonthAndYear, href } from '$lib/utils';
-	import { mode } from 'mode-watcher';
+        import Badge from '$lib/components/ui/badge/badge.svelte';
+        import Separator from '$lib/components/ui/separator/separator.svelte';
+        import H1 from '$lib/components/ui/typography/h1.svelte';
+        import Muted from '$lib/components/ui/typography/muted.svelte';
+        import Assets from '$lib/data/assets';
+        import ProjectsData from '$lib/data/projects';
+        import { translate, type LocalizedString } from '$lib/i18n';
+        import { language } from '$lib/stores/language';
+        import UiText from '$lib/data/ui';
+        import type { Project } from '$lib/data/types';
+        import { computeExactDuration, getMonthAndYear, href } from '$lib/utils';
+        import { mode } from 'mode-watcher';
 
-	let { data }: { data: { item?: Project } } = $props();
+        let { data }: { data: { item?: Project } } = $props();
 
-	let title = $derived(`${data?.item?.name ?? 'Not Found'} - Skills`);
+        const notFound: LocalizedString = { de: 'Nicht gefunden', en: 'Not found' };
+        let title = $derived(`${data?.item?.name ?? translate(notFound, $language)} - ${$ProjectsData.title}`);
 	let banner = $derived(
 		($mode == 'dark' ? data?.item?.logo.dark : data.item?.logo.light) ?? Assets.Unknown.light
 	);
@@ -68,7 +73,7 @@
 		<Separator />
 		<div class="flex flex-col gap-2 px-4 pt-4">
 			{#if data.item.screenshots && data.item.screenshots.length > 0}
-				<Muted>Screenshots</Muted>
+                                <Muted>{$UiText.screenshots}</Muted>
 				<div class="grid grid-cols-1 gap-2 py-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 					{#each data.item.screenshots as img, index (index)}
 						<ScreenshotCard item={img} />

--- a/src/routes/projects/[slug]/+page.ts
+++ b/src/routes/projects/[slug]/+page.ts
@@ -1,10 +1,11 @@
 import ProjectsData from '$lib/data/projects';
+import { get } from 'svelte/store';
 
 export function load({ params }: { params: Record<string, string> }) {
-	if (params.slug) {
-		const item = ProjectsData.items.find((item) => {
-			return item.slug === params.slug;
-		});
+        if (params.slug) {
+                const item = get(ProjectsData).items.find((item) => {
+                        return item.slug === params.slug;
+                });
 
 		return { item };
 	}

--- a/src/routes/resume/+page.svelte
+++ b/src/routes/resume/+page.svelte
@@ -1,12 +1,13 @@
 <script>
-	import TitledPage from '$lib/components/common/titled-page/titled-page.svelte';
-	import Button from '$lib/components/ui/button/button.svelte';
-	import ResumeData from '$lib/data/resume';
+        import TitledPage from '$lib/components/common/titled-page/titled-page.svelte';
+        import Button from '$lib/components/ui/button/button.svelte';
+        import ResumeData from '$lib/data/resume';
+        import UiText from '$lib/data/ui';
 </script>
 
-<TitledPage title={ResumeData.title}>
-	<a href={ResumeData.resume} class="mx-auto">
-		<Button>Download</Button>
-	</a>
-	<iframe src={ResumeData.resume} class="h-full w-full" title={ResumeData.title}></iframe>
+<TitledPage title={$ResumeData.title}>
+        <a href={$ResumeData.resume} class="mx-auto">
+                <Button>{$UiText.download}</Button>
+        </a>
+        <iframe src={$ResumeData.resume} class="h-full w-full" title={$ResumeData.title}></iframe>
 </TitledPage>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -5,19 +5,20 @@
 	import AvatarImage from '$lib/components/ui/avatar/avatar-image.svelte';
 	import Avatar from '$lib/components/ui/avatar/avatar.svelte';
 	import { CardContent, CardTitle } from '$lib/components/ui/card';
-	import FancyCard from '$lib/components/ui/card/fancy-card.svelte';
-	import Icon from '$lib/components/ui/icon/icon.svelte';
-	import Separator from '$lib/components/ui/separator/separator.svelte';
-	import { Tooltip, TooltipContent, TooltipTrigger } from '$lib/components/ui/tooltip';
-	import Large from '$lib/components/ui/typography/large.svelte';
-	import Assets from '$lib/data/assets';
-	import { NAMED_COLORS } from '$lib/data/colors';
-	import EducationData from '$lib/data/education';
-	import ExperienceData from '$lib/data/experience';
-	import ProjectsData from '$lib/data/projects';
-	import SkillsData from '$lib/data/skills';
-	import { href } from '$lib/utils';
-	import { mode } from 'mode-watcher';
+        import FancyCard from '$lib/components/ui/card/fancy-card.svelte';
+        import Icon from '$lib/components/ui/icon/icon.svelte';
+        import Separator from '$lib/components/ui/separator/separator.svelte';
+        import { Tooltip, TooltipContent, TooltipTrigger } from '$lib/components/ui/tooltip';
+        import Large from '$lib/components/ui/typography/large.svelte';
+        import UiText from '$lib/data/ui';
+        import Assets from '$lib/data/assets';
+        import { NAMED_COLORS } from '$lib/data/colors';
+        import EducationData from '$lib/data/education';
+        import ExperienceData from '$lib/data/experience';
+        import ProjectsData from '$lib/data/projects';
+        import SkillsData from '$lib/data/skills';
+        import { href } from '$lib/utils';
+        import { mode } from 'mode-watcher';
 
 	type Item = {
 		name: string;
@@ -35,67 +36,67 @@
 	let search = $state('');
 
 	const getResult = (q: string): Array<Group> => {
-		const skills = SkillsData.items.filter((it) => it.name.toLowerCase().includes(q.toLowerCase()));
-		const projects = ProjectsData.items.filter((it) =>
-			it.name.toLowerCase().includes(q.toLowerCase())
-		);
-		const experience = ExperienceData.items.filter((it) =>
-			it.name.toLowerCase().includes(q.toLowerCase())
-		);
-		const education = EducationData.items.filter((it) =>
-			it.name.toLowerCase().includes(q.toLowerCase())
-		);
+                const skills = $SkillsData.items.filter((it) => it.name.toLowerCase().includes(q.toLowerCase()));
+                const projects = $ProjectsData.items.filter((it) =>
+                        it.name.toLowerCase().includes(q.toLowerCase())
+                );
+                const experience = $ExperienceData.items.filter((it) =>
+                        it.name.toLowerCase().includes(q.toLowerCase())
+                );
+                const education = $EducationData.items.filter((it) =>
+                        it.name.toLowerCase().includes(q.toLowerCase())
+                );
 
 		const groups: Array<Group> = [];
 
 		if (skills.length) {
 			groups.push({
-				icon: 'i-carbon-assembly-cluster',
-				name: 'Skills',
-				items: skills.map((it) => ({
-					name: it.name,
-					logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
+                                icon: 'i-carbon-assembly-cluster',
+                                name: $SkillsData.title,
+                                items: skills.map((it) => ({
+                                        name: it.name,
+                                        logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
 					link: `/skills/${it.slug}`,
 					color: it.color
-				}))
-			});
-		}
+                                }))
+                        });
+                }
 
 		if (projects.length) {
 			groups.push({
-				icon: 'i-carbon-cube',
-				name: 'Projects',
-				items: projects.map((it) => ({
-					name: it.name,
-					logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
+                                icon: 'i-carbon-cube',
+                                name: $ProjectsData.title,
+                                items: projects.map((it) => ({
+                                        name: it.name,
+                                        logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
 					link: `/projects/${it.slug}`,
 					color: it.color
-				}))
-			});
-		}
+                                }))
+                        });
+                }
 
 		if (experience.length) {
 			groups.push({
-				icon: 'i-carbon-development',
-				name: 'Experience',
-				items: experience.map((it) => ({
-					name: it.name,
-					logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
+                                icon: 'i-carbon-development',
+                                name: $ExperienceData.title,
+                                items: experience.map((it) => ({
+                                        name: it.name,
+                                        logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
 					link: `/experience/${it.slug}`,
 					color: it.color
-				}))
-			});
-		}
+                                }))
+                        });
+                }
 
 		if (education.length) {
 			groups.push({
-				icon: 'i-carbon-education',
-				name: 'Education',
-				items: education.map((it) => ({
-					name: it.degree,
-					logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
-					link: `/education/${it.slug}`,
-					color: NAMED_COLORS.gray
+                                icon: 'i-carbon-education',
+                                name: $EducationData.title,
+                                items: education.map((it) => ({
+                                        name: it.degree,
+                                        logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
+                                        link: `/education/${it.slug}`,
+                                        color: NAMED_COLORS.gray
 				}))
 			});
 		}
@@ -103,12 +104,12 @@
 		return groups;
 	};
 
-	let result = $derived(getResult(search));
+        let result = $derived(getResult(search));
 
-	const onSearch = (query: string) => (search = query);
+        const onSearch = (query: string) => (search = query);
 </script>
 
-<SearchPage title="Search" {onSearch}>
+<SearchPage title={$UiText.search} {onSearch}>
 	{#if result.length === 0}
 		<EmptyResult />
 	{:else}

--- a/src/routes/skills/+page.svelte
+++ b/src/routes/skills/+page.svelte
@@ -6,9 +6,10 @@
 	import FancyCard from '$lib/components/ui/card/fancy-card.svelte';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import Muted from '$lib/components/ui/typography/muted.svelte';
-	import SkillsData, { groupByCategory } from '$lib/data/skills';
-	import { href } from '$lib/utils';
-	import { mode } from 'mode-watcher';
+        import SkillsData, { groupByCategory } from '$lib/data/skills';
+        import { language } from '$lib/stores/language';
+        import { href } from '$lib/utils';
+        import { mode } from 'mode-watcher';
 
 	let query = $state('');
 
@@ -16,10 +17,10 @@
 		query = value;
 	}
 
-	const groups = $derived(groupByCategory(query));
+        const groups = $derived(groupByCategory($language, $SkillsData.items, query));
 </script>
 
-<SearchPage title={SkillsData.title} {onSearch}>
+<SearchPage title={$SkillsData.title} {onSearch}>
 	{#if groups.length === 0}
 		<EmptyResult />
 	{:else}

--- a/src/routes/skills/[slug]/+page.svelte
+++ b/src/routes/skills/[slug]/+page.svelte
@@ -1,23 +1,28 @@
 <script lang="ts">
 	import BasePage from '$lib/components/common/base-page/base-page.svelte';
 	import EmptyResult from '$lib/components/common/empty-result/empty-result.svelte';
-	import FancyBanner from '$lib/components/common/fancy-banner/fancy-banner.svelte';
-	import EmptyMarkdown from '$lib/components/common/markdown/empty-markdown.svelte';
-	import Markdown from '$lib/components/common/markdown/markdown.svelte';
-	import { Badge } from '$lib/components/ui/badge';
-	import Separator from '$lib/components/ui/separator/separator.svelte';
-	import H1 from '$lib/components/ui/typography/h1.svelte';
-	import Muted from '$lib/components/ui/typography/muted.svelte';
-	import Assets from '$lib/data/assets';
-	import ExperienceData from '$lib/data/experience';
-	import ProjectsData from '$lib/data/projects';
-	import type { Skill } from '$lib/data/types';
-	import { href } from '$lib/utils';
-	import { mode } from 'mode-watcher';
+        import FancyBanner from '$lib/components/common/fancy-banner/fancy-banner.svelte';
+        import EmptyMarkdown from '$lib/components/common/markdown/empty-markdown.svelte';
+        import Markdown from '$lib/components/common/markdown/markdown.svelte';
+        import { Badge } from '$lib/components/ui/badge';
+        import Separator from '$lib/components/ui/separator/separator.svelte';
+        import H1 from '$lib/components/ui/typography/h1.svelte';
+        import Muted from '$lib/components/ui/typography/muted.svelte';
+        import Assets from '$lib/data/assets';
+        import SkillsData from '$lib/data/skills';
+        import UiText from '$lib/data/ui';
+        import { translate, type LocalizedString } from '$lib/i18n';
+        import { language } from '$lib/stores/language';
+        import ExperienceData from '$lib/data/experience';
+        import ProjectsData from '$lib/data/projects';
+        import type { Skill } from '$lib/data/types';
+        import { href } from '$lib/utils';
+        import { mode } from 'mode-watcher';
 
 	let { data }: { data: { item?: Skill } } = $props();
 
-	let title = $derived(`${data?.item?.name ?? 'Not Found'} - Skills`);
+        const notFound: LocalizedString = { de: 'Nicht gefunden', en: 'Not found' };
+        let title = $derived(`${data?.item?.name ?? translate(notFound, $language)} - ${$SkillsData.title}`);
 	let banner = $derived(
 		($mode == 'dark' ? data?.item?.logo.dark : data.item?.logo.light) ?? Assets.Unknown.light
 	);
@@ -30,20 +35,20 @@
 
 			const items: Array<{ name: string; logo: string; link: string }> = [];
 
-			ProjectsData.items.forEach((it) => {
-				if (it.skills.find((skill) => skill.slug === current.slug)) {
-					items.push({
-						link: `/projects/${it.slug}`,
+                        $ProjectsData.items.forEach((it) => {
+                                if (it.skills.find((skill) => skill.slug === current.slug)) {
+                                        items.push({
+                                                link: `/projects/${it.slug}`,
 						logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
 						name: it.name
 					});
 				}
 			});
 
-			ExperienceData.items.forEach((it) => {
-				if (it.skills.find((skill) => skill.slug === current.slug)) {
-					items.push({
-						link: `/experience/${it.slug}`,
+                        $ExperienceData.items.forEach((it) => {
+                                if (it.skills.find((skill) => skill.slug === current.slug)) {
+                                        items.push({
+                                                link: `/experience/${it.slug}`,
 						logo: $mode === 'dark' ? it.logo.dark : it.logo.light,
 						name: it.name
 					});
@@ -71,7 +76,7 @@
 		<Separator />
 		{#if related.length !== 0}
 			<div class="flex flex-row flex-wrap items-center gap-2 py-4">
-				<Muted>Related items</Muted>
+                                <Muted>{$UiText.relatedItems}</Muted>
 				{#each related as item}
 					<a href={href(item.link)}>
 						<Badge>{item.name}</Badge>

--- a/src/routes/skills/[slug]/+page.ts
+++ b/src/routes/skills/[slug]/+page.ts
@@ -1,10 +1,11 @@
 import SkillsData from '$lib/data/skills';
+import { get } from 'svelte/store';
 
 export function load({ params }: { params: Record<string, string> }) {
-	if (params.slug) {
-		const item = SkillsData.items.find((item) => {
-			return item.slug === params.slug;
-		});
+        if (params.slug) {
+                const item = get(SkillsData).items.find((item) => {
+                        return item.slug === params.slug;
+                });
 
 		return { item };
 	}


### PR DESCRIPTION
## Summary
- add a language store and shared UI copy to support German/English switching
- localize navigation, section data, and shared components with bilingual content
- update pages and detail views to render translated text based on the selected language

## Testing
- npm run check *(fails: existing class type mismatches and aria warning in UI components)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2ee07d3c8328aa0d929ca3cbfd88)